### PR TITLE
Allow setting the controller base path

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -11,15 +11,16 @@ interface ControllerFile {
 
 export class Project {
   readonly projectPath: string
-  readonly controllerPath = "app/javascript/controllers"
+  readonly controllerPath: string
 
   controllerDefinitions: ControllerDefinition[] = []
 
   private controllerFiles: Array<ControllerFile> = []
   private parser: Parser = new Parser(this)
 
-  constructor(projectPath: string) {
+  constructor(projectPath: string, controllerPath = "app/javascript/controllers") {
     this.projectPath = projectPath
+    this.controllerPath = controllerPath
   }
 
   relativePath(path: string) {

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "vitest"
 import { Project } from "../src"
 
-const project = new Project("/Users/marcoroth/Development/stimulus-parser")
+const TEST_PROJECT_PATH = "/Users/marcoroth/Development/stimulus-parser";
+
+const project = new Project(TEST_PROJECT_PATH)
+const projectWithCustomControllerPath = new Project(TEST_PROJECT_PATH, "resources/js/controllers")
 
 test("relativePath", () => {
   expect(project.relativePath("/Users/marcoroth/Development/stimulus-parser/path/to/some/file.js")).toEqual(
@@ -23,6 +26,24 @@ test("relativeControllerPath", () => {
   expect(
     project.relativeControllerPath(
       "/Users/marcoroth/Development/stimulus-parser/app/javascript/controllers/nested/deeply/some_controller.js"
+    )
+  ).toEqual("nested/deeply/some_controller.js")
+})
+
+test("relativeControllerPath with custom controller path", () => {
+  expect(
+    projectWithCustomControllerPath.relativeControllerPath(
+      "/Users/marcoroth/Development/stimulus-parser/resources/js/controllers/some_controller.js"
+    )
+  ).toEqual("some_controller.js")
+  expect(
+    projectWithCustomControllerPath.relativeControllerPath(
+      "/Users/marcoroth/Development/stimulus-parser/resources/js/controllers/nested/some_controller.js"
+    )
+  ).toEqual("nested/some_controller.js")
+  expect(
+    projectWithCustomControllerPath.relativeControllerPath(
+      "/Users/marcoroth/Development/stimulus-parser/resources/js/controllers/nested/deeply/some_controller.js"
     )
   ).toEqual("nested/deeply/some_controller.js")
 })


### PR DESCRIPTION
### Changed

- Allows passing a custom controller path. This allows other frameworks to integrate with the Stimulus LSP