### PR TITLE
Introduce `controllerRoot` and `controllerRoots` on `Project`

### DIFF
--- a/test/fixtures/controller-paths/app/javascript/controllers/nested/rails_controller.js
+++ b/test/fixtures/controller-paths/app/javascript/controllers/nested/rails_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/fixtures/controller-paths/app/javascript/controllers/nested/twice/rails_controller.js
+++ b/test/fixtures/controller-paths/app/javascript/controllers/nested/twice/rails_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/fixtures/controller-paths/app/javascript/controllers/rails_controller.js
+++ b/test/fixtures/controller-paths/app/javascript/controllers/rails_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/fixtures/controller-paths/app/pack/controllers/nested/twice/webpack_controller.js
+++ b/test/fixtures/controller-paths/app/pack/controllers/nested/twice/webpack_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/fixtures/controller-paths/app/pack/controllers/nested/webpack_controller.js
+++ b/test/fixtures/controller-paths/app/pack/controllers/nested/webpack_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/fixtures/controller-paths/app/pack/webpack_controller.js
+++ b/test/fixtures/controller-paths/app/pack/webpack_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/fixtures/controller-paths/resources/js/controllers/laravel_controller.js
+++ b/test/fixtures/controller-paths/resources/js/controllers/laravel_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/fixtures/controller-paths/resources/js/controllers/nested/laravel_controller.js
+++ b/test/fixtures/controller-paths/resources/js/controllers/nested/laravel_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/fixtures/controller-paths/resources/js/controllers/nested/twice/laravel_controller.js
+++ b/test/fixtures/controller-paths/resources/js/controllers/nested/twice/laravel_controller.js
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {}

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -28,7 +28,7 @@ test("relativeControllerPath", () => {
 })
 
 test("controllerRoot and controllerRoots", async () => {
-  const project = new Project("/Users/marcoroth/Development/stimulus-parser/test/fixtures/controller-paths")
+  const project = new Project("test/fixtures/controller-paths")
 
   expect(project.controllerRootFallback).toEqual("app/javascript/controllers")
   expect(project.controllerRoot).toEqual("app/javascript/controllers")

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -26,3 +26,53 @@ test("relativeControllerPath", () => {
     )
   ).toEqual("nested/deeply/some_controller.js")
 })
+
+test("controllerRoot and controllerRoots", async () => {
+  const project = new Project("/Users/marcoroth/Development/stimulus-parser/test/fixtures/controller-paths")
+
+  expect(project.controllerRootFallback).toEqual("app/javascript/controllers")
+  expect(project.controllerRoot).toEqual("app/javascript/controllers")
+  expect(project.controllerRoots).toEqual([])
+
+  await project.analyze()
+
+  expect(project.controllerRoot).toEqual("app/javascript/controllers")
+
+  expect(project.controllerRoots).toEqual([
+    "app/javascript/controllers",
+    "app/pack/controllers",
+    "resources/js/controllers",
+  ])
+})
+
+test("static calculateControllerRoots", () => {
+  expect(
+    Project.calculateControllerRoots([
+      "app/javascript/controllers/some_controller.js",
+      "app/javascript/controllers/nested/some_controller.js",
+      "app/javascript/controllers/nested/deeply/some_controller.js",
+    ])
+  ).toEqual([
+    "app/javascript/controllers"
+  ])
+
+  expect(
+    Project.calculateControllerRoots(
+      [
+        "app/packs/controllers/some_controller.js",
+        "app/packs/controllers/nested/some_controller.js",
+        "app/packs/controllers/nested/deeply/some_controller.js",
+        "app/javascript/controllers/some_controller.js",
+        "app/javascript/controllers/nested/some_controller.js",
+        "app/javascript/controllers/nested/deeply/some_controller.js",
+        "resources/js/controllers/some_controller.js",
+        "resources/js/controllers/nested/some_controller.js",
+        "resources/js/controllers/nested/deeply/some_controller.js",
+      ]
+    )
+  ).toEqual([
+    "app/javascript/controllers",
+    "app/packs/controllers",
+    "resources/js/controllers"
+  ])
+})


### PR DESCRIPTION
This pull request introduces the `controllerRoot` and `controllerRoots` getters on `Project`.

The `Project` class now tries to detect the controller root folders based on the detected Stimulus controllers files. It now also exposes a new static `calculateControllerRoots` method on `Project` to calculate controller roots.

This enables us : 
* ... to handle cases where people have multiple folders where they have controller definitions in (see https://github.com/marcoroth/stimulus-lsp/issues/26)
* ... to handle cases where people don't have their controllers in the previously hard-coded location (`app/javascript/controllers`), which should allow to support other frameworks as well (see https://github.com/marcoroth/stimulus-lsp/pull/31)


This might also cover the cases/use-case outlined in https://github.com/marcoroth/stimulus-parser/pull/14