### PR TITLE
Parse controllers with class fields without value correctly

### DIFF
--- a/src/parser.ts
+++ b/src/parser.ts
@@ -42,7 +42,7 @@ export class Parser {
         PropertyDefinition(node: any): void {
           const { name } = node.key
 
-          if (node.value.type === "ArrowFunctionExpression") {
+          if (node.value && node.value.type === "ArrowFunctionExpression") {
             controller.methods.push(name)
           }
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -148,3 +148,20 @@ test.skip("parse nested object/array default value types", () => {
     array: { type: "Array", default: [["Array", "with", ["nested", ["values"]]]] },
   })
 })
+
+test("parse controller with public class fields", () => {
+  const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      someField
+      static someOtherField
+
+      static targets = ["one", "two", "three"]
+    }
+  `
+
+  const controller = parser.parseController(code, "target_controller.js")
+
+  expect(controller.targets).toEqual(["one", "two", "three"])
+})

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -154,14 +154,14 @@ test("parse controller with public class fields", () => {
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
-      someField
-      static someOtherField
-
-      static targets = ["one", "two", "three"]
+      instanceField
+      instanceFieldWithInitializer = "instance field"
+      static staticField
+      static staticFieldWithInitializer = "static field"
     }
   `
 
   const controller = parser.parseController(code, "target_controller.js")
 
-  expect(controller.targets).toEqual(["one", "two", "three"])
+  expect(controller.parseError).toBeUndefined()
 })


### PR DESCRIPTION
I took a stab at fixing the bug I reported in #20. 

Let me know what you think! I've added an extra test, doubted to extend the first test to have the class fields, but then it's not clear why they're there.