### PR TITLE
Add support for private getters

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,10 +21,7 @@
   "dependencies": {
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "acorn": "^8.11.2",
-    "acorn-class-fields": "^1.0.0",
-    "acorn-private-methods": "^1.0.0",
-    "acorn-static-class-features": "^1.0.0",
-    "acorn-walk": "^8.3.0",
+    "acorn-walk": "^8.3.1",
     "fs": "^0.0.1-security",
     "glob": "^10.3.4"
   },

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -1,13 +1,10 @@
 import { simple } from "acorn-walk"
 import { Parser as AcornParser } from "acorn"
-import type { Program } from "acorn"
-import staticClassFeatures from "acorn-static-class-features"
-import privateMethods from "acorn-private-methods"
-import classFields from "acorn-class-fields"
-
 import { Project } from "./project"
 import { ControllerDefinition, defaultValuesForType } from "./controller_definition"
 import { NodeElement, PropertyValue } from "./types"
+
+import type { Program } from "acorn"
 
 type NestedArray<T> = T | NestedArray<T>[]
 type NestedObject<T> = {
@@ -21,15 +18,12 @@ export class Parser {
   constructor(project: Project) {
     this.project = project
     this.parser = AcornParser
-      .extend(staticClassFeatures)
-      .extend(privateMethods)
-      .extend(classFields)
   }
 
   parse(code: string): Program {
     return this.parser.parse(code, {
       sourceType: "module",
-      ecmaVersion: 2020,
+      ecmaVersion: "latest",
     })
   }
 

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -181,3 +181,20 @@ test("parse controller with private getter", () => {
   expect(controller.parseError).toBeUndefined()
   expect(controller.methods).toEqual([])
 })
+
+test("parse controller with private setter", () => {
+  const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      set #privateSetter (value) {
+        // set
+      }
+    }
+  `
+
+  const controller = parser.parseController(code, "controller.js")
+
+  expect(controller.parseError).toBeUndefined()
+  expect(controller.methods).toEqual([])
+})

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -160,7 +160,24 @@ test("parse controller with public class fields", () => {
     }
   `
 
-  const controller = parser.parseController(code, "target_controller.js")
+  const controller = parser.parseController(code, "controller.js")
 
   expect(controller.parseError).toBeUndefined()
+})
+
+test("parse controller with private getter", () => {
+  const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      get #privateGetter () {
+        return true
+      }
+    }
+  `
+
+  const controller = parser.parseController(code, "controller.js")
+
+  expect(controller.parseError).toBeUndefined()
+  expect(controller.methods).toEqual([])
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -327,33 +327,7 @@
     loupe "^2.3.7"
     pretty-format "^29.7.0"
 
-acorn-class-fields@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-class-fields/-/acorn-class-fields-1.0.0.tgz#b413793e6b3ddfcd17a02f9c7a850f4bbfdc1c7a"
-  integrity sha512-l+1FokF34AeCXGBHkrXFmml9nOIRI+2yBnBpO5MaVAaTIJ96irWLtcCxX+7hAp6USHFCe+iyyBB4ZhxV807wmA==
-  dependencies:
-    acorn-private-class-elements "^1.0.0"
-
-acorn-private-class-elements@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-private-class-elements/-/acorn-private-class-elements-1.0.0.tgz#c5805bf8a46cd065dc9b3513bfebb504c88cd706"
-  integrity sha512-zYNcZtxKgVCg1brS39BEou86mIao1EV7eeREG+6WMwKbuYTeivRRs6S2XdWnboRde6G9wKh2w+WBydEyJsJ6mg==
-
-acorn-private-methods@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-private-methods/-/acorn-private-methods-1.0.0.tgz#b48f4c03a151cc8262f6f5ca8f57f7c5ac245184"
-  integrity sha512-Jou2L3nfwfPpFdmmHObI3yUpVPM1bPohTUAZCyVDw5Efyn9LSS6E36neRLCRfIr8QjskAfdxRdABOrvP4c/gwQ==
-  dependencies:
-    acorn-private-class-elements "^1.0.0"
-
-acorn-static-class-features@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/acorn-static-class-features/-/acorn-static-class-features-1.0.0.tgz#ab9d862d5b184007ed509f5a8d031b837694ace2"
-  integrity sha512-XZJECjbmMOKvMHiNzbiPXuXpLAJfN3dAKtfIYbk1eHiWdsutlek+gS7ND4B8yJ3oqvHo1NxfafnezVmq7NXK0A==
-  dependencies:
-    acorn-private-class-elements "^1.0.0"
-
-acorn-walk@^8.1.1, acorn-walk@^8.3.0:
+acorn-walk@^8.1.1, acorn-walk@^8.3.0, acorn-walk@^8.3.1:
   version "8.3.1"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.1.tgz#2f10f5b69329d90ae18c58bf1fa8fccd8b959a43"
   integrity sha512-TgUZgYvqZprrl7YldZNoa9OciCAyZR+Ejm9eXzKCmjsF5IKp/wgQ7Z/ZpjpGTIUPwrHQIcYeI8qDh4PsEwxMbw==


### PR DESCRIPTION
This pull request bumps the `ecmaScript` version `"latest"` when parsing the source files and therefore also removes the need for the additional acorn plugins like [`acorn-private-methods`](https://github.com/acornjs/acorn-private-methods), [`acorn-static-class-features`](https://github.com/acornjs/acorn-static-class-features), and [`acorn-class-fields`](https://github.com/acornjs/acorn-class-fields).

Fixes #31 