### PR TITLE
Feat/Support Typescript Syntax

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "acorn": "^8.11.2",
+    "acorn-typescript": "^1.4.13",
     "acorn-walk": "^8.3.1",
     "fs": "^0.0.1-security",
     "glob": "^10.3.10"

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,6 +5,7 @@ import { ControllerDefinition, defaultValuesForType } from "./controller_definit
 import { NodeElement, PropertyValue } from "./types"
 
 import type { Program } from "acorn"
+import tsPlugin from "acorn-typescript"
 
 type NestedArray<T> = T | NestedArray<T>[]
 type NestedObject<T> = {
@@ -17,13 +18,14 @@ export class Parser {
 
   constructor(project: Project) {
     this.project = project
-    this.parser = AcornParser
+    this.parser = AcornParser.extend(tsPlugin() as any)
   }
 
   parse(code: string): Program {
     return this.parser.parse(code, {
       sourceType: "module",
       ecmaVersion: "latest",
+      locations: true
     })
   }
 
@@ -124,7 +126,7 @@ export class Parser {
       })
 
       return controller
-    } catch(error: any) {
+    } catch (error: any) {
       console.error(`Error while parsing controller in '${filename}': ${error.message}`)
 
       const controller = new ControllerDefinition(this.project, filename)

--- a/src/project.ts
+++ b/src/project.ts
@@ -52,7 +52,7 @@ export class Project {
   }
 
   get controllerRoot() {
-    return this.controllerRoots[0] || this.controllerRootFallback
+    return this.controllerRoots[0] || this.controllerRootFallback
   }
 
   get controllerRoots() {
@@ -76,11 +76,11 @@ export class Project {
     const relativePath = this.relativePath(path)
     const relativeRoots = this.controllerRoots.map(root => this.relativePath(root))
 
-    return relativeRoots.find(root => relativePath.startsWith(root)) || this.controllerRootFallback
+    return relativeRoots.find(root => relativePath.startsWith(root)) || this.controllerRootFallback
   }
 
   private async readControllerFiles() {
-    const controllerFiles = await glob(`${this.projectPath}/**/*_controller.js`, {
+    const controllerFiles = await glob(`${this.projectPath}/**/*_controller.{js,ts}`, {
       ignore: `${this.projectPath}/node_modules/**/*`,
     })
 

--- a/test/fixtures/controller-paths/app/javascript/controllers/rails_ts_controller.ts
+++ b/test/fixtures/controller-paths/app/javascript/controllers/rails_ts_controller.ts
@@ -1,0 +1,3 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller { }

--- a/test/parser.test.ts
+++ b/test/parser.test.ts
@@ -1,37 +1,39 @@
 import { expect, test, vi } from "vitest"
 import { Project, Parser } from "../src"
+import { describe } from "node:test"
 
 const project = new Project("/Users/marcoroth/Development/stimulus-parser")
 const parser = new Parser(project)
 
-test("parse targets", () => {
-  const code = `
+describe("with JS Syntax", () => {
+  test("parse targets", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
       static targets = ["one", "two", "three"]
     }
   `
-  const controller = parser.parseController(code, "target_controller.js")
+    const controller = parser.parseController(code, "target_controller.js")
 
-  expect(controller.targets).toEqual(["one", "two", "three"])
-})
+    expect(controller.targets).toEqual(["one", "two", "three"])
+  })
 
-test("parse classes", () => {
-  const code = `
+  test("parse classes", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
       static classes = ["one", "two", "three"]
     }
   `
-  const controller = parser.parseController(code, "class_controller.js")
+    const controller = parser.parseController(code, "class_controller.js")
 
-  expect(controller.classes).toEqual(["one", "two", "three"])
-})
+    expect(controller.classes).toEqual(["one", "two", "three"])
+  })
 
-test("parse values", () => {
-  const code = `
+  test("parse values", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
@@ -44,19 +46,19 @@ test("parse values", () => {
       }
     }
   `
-  const controller = parser.parseController(code, "value_controller.js")
+    const controller = parser.parseController(code, "value_controller.js")
 
-  expect(controller.values).toEqual({
-    string: { type: "String", default: "" },
-    object: { type: "Object", default: {} },
-    boolean: { type: "Boolean", default: false },
-    array: { type: "Array", default: [] },
-    number: { type: "Number", default: 0 },
+    expect(controller.values).toEqual({
+      string: { type: "String", default: "" },
+      object: { type: "Object", default: {} },
+      boolean: { type: "Boolean", default: false },
+      array: { type: "Array", default: [] },
+      number: { type: "Number", default: 0 },
+    })
   })
-})
 
-test("parse values with with default values", () => {
-  const code = `
+  test("parse values with with default values", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
@@ -69,35 +71,35 @@ test("parse values with with default values", () => {
       }
     }
   `
-  const controller = parser.parseController(code, "value_controller.js")
+    const controller = parser.parseController(code, "value_controller.js")
 
-  expect(controller.values).toEqual({
-    string: { type: "String", default: "string" },
-    object: { type: "Object", default: { object: "Object" } },
-    boolean: { type: "Boolean", default: true },
-    array: { type: "Array", default: ["Array"] },
-    number: { type: "Number", default: 1 },
+    expect(controller.values).toEqual({
+      string: { type: "String", default: "string" },
+      object: { type: "Object", default: { object: "Object" } },
+      boolean: { type: "Boolean", default: true },
+      array: { type: "Array", default: ["Array"] },
+      number: { type: "Number", default: 1 },
+    })
   })
-})
 
-test("should handle syntax errors", () => {
-  const code = `
+  test("should handle syntax errors", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
   `
-  const spy = vi.spyOn(console, 'error')
+    const spy = vi.spyOn(console, 'error')
 
-  const controller = parser.parseController(code, "error_controller.js")
+    const controller = parser.parseController(code, "error_controller.js")
 
-  expect(controller.identifier).toEqual("error")
-  expect(controller.parseError).toEqual("Unexpected token (5:2)")
+    expect(controller.identifier).toEqual("error")
+    expect(controller.parseError).toEqual("Unexpected token (5:2)")
 
-  expect(spy).toBeCalledWith("Error while parsing controller in 'error_controller.js': Unexpected token (5:2)")
-})
+    expect(spy).toBeCalledWith("Error while parsing controller in 'error_controller.js': Unexpected token (5:2)")
+  })
 
-test("parse arrow function", () => {
-  const code = `
+  test("parse arrow function", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
@@ -109,28 +111,28 @@ test("parse arrow function", () => {
     }
   `
 
-  const controller = parser.parseController(code, "controller.js")
+    const controller = parser.parseController(code, "controller.js")
 
-  expect(controller.methods).toEqual(["connect", "load"])
-  expect(controller.parseError).toBeUndefined()
-})
+    expect(controller.methods).toEqual(["connect", "load"])
+    expect(controller.parseError).toBeUndefined()
+  })
 
-test("parse private methods", () => {
-  const code = `
+  test("parse private methods", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
       #load() {}
     }
   `
-  const controller = parser.parseController(code, "controller.js")
+    const controller = parser.parseController(code, "controller.js")
 
-  expect(controller.methods).toEqual(["load"])
-  expect(controller.parseError).toBeUndefined()
-})
+    expect(controller.methods).toEqual(["load"])
+    expect(controller.parseError).toBeUndefined()
+  })
 
-test("parse nested object/array default value types", () => {
-  const code = `
+  test("parse nested object/array default value types", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
@@ -140,16 +142,16 @@ test("parse nested object/array default value types", () => {
       }
     }
   `
-  const controller = parser.parseController(code, "value_controller.js")
+    const controller = parser.parseController(code, "value_controller.js")
 
-  expect(controller.values).toEqual({
-    object: { type: "Object", default: { object: { some: { more: { levels: {} } } } } },
-    array: { type: "Array", default: [["Array", "with", ["nested", ["values"]]]] },
+    expect(controller.values).toEqual({
+      object: { type: "Object", default: { object: { some: { more: { levels: {} } } } } },
+      array: { type: "Array", default: [["Array", "with", ["nested", ["values"]]]] },
+    })
   })
-})
 
-test("parse controller with public class fields", () => {
-  const code = `
+  test("parse controller with public class fields", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
@@ -160,13 +162,13 @@ test("parse controller with public class fields", () => {
     }
   `
 
-  const controller = parser.parseController(code, "controller.js")
+    const controller = parser.parseController(code, "controller.js")
 
-  expect(controller.parseError).toBeUndefined()
-})
+    expect(controller.parseError).toBeUndefined()
+  })
 
-test("parse controller with private getter", () => {
-  const code = `
+  test("parse controller with private getter", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
@@ -176,14 +178,14 @@ test("parse controller with private getter", () => {
     }
   `
 
-  const controller = parser.parseController(code, "controller.js")
+    const controller = parser.parseController(code, "controller.js")
 
-  expect(controller.parseError).toBeUndefined()
-  expect(controller.methods).toEqual([])
-})
+    expect(controller.parseError).toBeUndefined()
+    expect(controller.methods).toEqual([])
+  })
 
-test("parse controller with private setter", () => {
-  const code = `
+  test("parse controller with private setter", () => {
+    const code = `
     import { Controller } from "@hotwired/stimulus"
 
     export default class extends Controller {
@@ -193,8 +195,222 @@ test("parse controller with private setter", () => {
     }
   `
 
-  const controller = parser.parseController(code, "controller.js")
+    const controller = parser.parseController(code, "controller.js")
 
-  expect(controller.parseError).toBeUndefined()
-  expect(controller.methods).toEqual([])
+    expect(controller.parseError).toBeUndefined()
+    expect(controller.methods).toEqual([])
+  })
+})
+
+describe("with TS Syntax", () => {
+  test("parse targets", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      static targets = ["one", "two", "three"]
+
+      declare readonly oneTarget: HTMLElement
+      declare readonly twoTarget: HTMLElement
+      declare readonly threeTarget: HTMLElement
+    }
+  `
+    const controller = parser.parseController(code, "target_controller.ts")
+
+    expect(controller.targets).toEqual(["one", "two", "three"])
+  })
+
+  test("parse classes", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      static classes = ["one", "two", "three"]
+    }
+  `
+    const controller = parser.parseController(code, "class_controller.ts")
+
+    expect(controller.classes).toEqual(["one", "two", "three"])
+  })
+
+  test("parse values", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      static values = {
+        string: String,
+        object: Object,
+        boolean: Boolean,
+        array: Array,
+        number: Number
+      }
+
+      declare stringValue: string
+      declare objectValue: object
+      declare booleanValue: boolean
+      declare arrayValue: any[]
+      declare numberValue: number
+    }
+  `
+    const controller = parser.parseController(code, "value_controller.ts")
+
+    expect(controller.values).toEqual({
+      string: { type: "String", default: "" },
+      object: { type: "Object", default: {} },
+      boolean: { type: "Boolean", default: false },
+      array: { type: "Array", default: [] },
+      number: { type: "Number", default: 0 },
+    })
+  })
+
+  test("parse values with with default values", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      static values = {
+        string: { type: String, default: "string" },
+        object: { type: Object, default: { object: "Object" } },
+        boolean: { type: Boolean, default: true },
+        array: { type: Array, default: ["Array"] },
+        number: { type: Number, default: 1 }
+      }
+
+      declare stringValue: string
+      declare objectValue: object
+      declare booleanValue: boolean
+      declare arrayValue: any[]
+      declare numberValue: number
+    }
+  `
+    const controller = parser.parseController(code, "value_controller.ts")
+
+    expect(controller.values).toEqual({
+      string: { type: "String", default: "string" },
+      object: { type: "Object", default: { object: "Object" } },
+      boolean: { type: "Boolean", default: true },
+      array: { type: "Array", default: ["Array"] },
+      number: { type: "Number", default: 1 },
+    })
+  })
+
+  test("should handle syntax errors", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+  `
+    const spy = vi.spyOn(console, 'error')
+
+    const controller = parser.parseController(code, "error_controller.ts")
+
+    expect(controller.identifier).toEqual("error")
+    expect(controller.parseError).toEqual("Unexpected token (5:2)")
+
+    expect(spy).toBeCalledWith("Error while parsing controller in 'error_controller.ts': Unexpected token (5:2)")
+  })
+
+  test("parse arrow function", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      connect():void {
+        document.addEventListener('event', this.load)
+      }
+
+      load = (event: Event):void => {}
+    }
+  `
+
+    const controller = parser.parseController(code, "controller.ts")
+
+    expect(controller.methods).toEqual(["connect", "load"])
+    expect(controller.parseError).toBeUndefined()
+  })
+
+  test("parse private methods", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      private load() {}
+    }
+  `
+    const controller = parser.parseController(code, "controller.ts")
+
+    expect(controller.methods).toEqual(["load"])
+    expect(controller.parseError).toBeUndefined()
+  })
+
+  test("parse nested object/array default value types", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      static values = {
+        object: { type: Object, default: { object: { some: { more: { levels: {} } } } } },
+        array: { type: Array, default: [["Array", "with", ["nested", ["values"]]]] },
+      }
+    }
+  `
+    const controller = parser.parseController(code, "value_controller.js")
+
+    expect(controller.values).toEqual({
+      object: { type: "Object", default: { object: { some: { more: { levels: {} } } } } },
+      array: { type: "Array", default: [["Array", "with", ["nested", ["values"]]]] },
+    })
+  })
+
+  test("parse controller with public class fields", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      instanceField: any;
+      instanceFieldWithInitializer: string = "instance field";
+      static staticField: any;
+      static staticFieldWithInitializer: string = "static field";
+    }
+  `
+
+    const controller = parser.parseController(code, "controller.ts")
+
+    expect(controller.parseError).toBeUndefined()
+  })
+
+  test("parse controller with private getter", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      private get privateGetter () {
+        return true
+      }
+    }
+  `
+
+    const controller = parser.parseController(code, "controller.ts")
+
+    expect(controller.parseError).toBeUndefined()
+    expect(controller.methods).toEqual([])
+  })
+
+  test("parse controller with private setter", () => {
+    const code = `
+    import { Controller } from "@hotwired/stimulus"
+
+    export default class extends Controller {
+      private set privateSetter (value) {
+        // set
+      }
+    }
+  `
+
+    const controller = parser.parseController(code, "controller.ts")
+
+    expect(controller.parseError).toBeUndefined()
+    expect(controller.methods).toEqual([])
+  })
 })

--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -61,6 +61,7 @@ test("identifier in different controllerRoots", async () => {
     "nested--twice--webpack",
     "nested--webpack",
     "rails",
+    "rails-ts",
     "webpack",
   ])
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -317,6 +317,11 @@
     loupe "^2.3.7"
     pretty-format "^29.7.0"
 
+acorn-typescript@^1.4.13:
+  version "1.4.13"
+  resolved "https://registry.yarnpkg.com/acorn-typescript/-/acorn-typescript-1.4.13.tgz#5f851c8bdda0aa716ffdd5f6ac084df8acc6f5ea"
+  integrity sha512-xsc9Xv0xlVfwp2o7sQ+GCQ1PgbkdcpWdTzrwXxO3xDMTAywVS3oXVOcOHuRjAPkS4P9b+yc/qNF15460v+jp4Q==
+
 acorn-walk@^8.1.1, acorn-walk@^8.3.1, acorn-walk@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.2.tgz#7703af9415f1b6db9315d6895503862e231d34aa"


### PR DESCRIPTION
Hey @marcoroth, as per the tests, this seems to be working.

However, [same as @Zeko369]([Zeko369](https://github.com/Zeko369)), I haven't been able to figure out the type mismatch error. Seems to be an issue with the constructors:

`Cannot assign a 'private' constructor type to a 'public' constructor type.`

If this looks good to you, and works, maybe we can use it, and in parallel we open an issue for this in https://github.com/TyrealHu/acorn-typescript?
