### PR TITLE
Basic support for parsing parent controllers

### DIFF
--- a/src/controller_definition.ts
+++ b/src/controller_definition.ts
@@ -8,6 +8,16 @@ type ValueDefinition = {
   default: ValueDefinitionValue
 }
 
+type ParentController = {
+  controllerFile?: string
+  constant: string
+  identifier?: string
+  definition?: ControllerDefinition
+  package?: string
+  parent?: ParentController
+  type: "default" | "application" | "package" | "import" | "unknown"
+}
+
 export const defaultValuesForType = {
   Array: [],
   Boolean: false,
@@ -19,6 +29,7 @@ export const defaultValuesForType = {
 export class ControllerDefinition {
   readonly path: string
   readonly project: Project
+  parent?: ParentController
 
   methods: Array<string> = []
   targets: Array<string> = []

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -29,10 +29,39 @@ export class Parser {
 
   parseController(code: string, filename: string) {
     try {
+      const importStatements = []
       const ast = this.parse(code, filename)
       const controller = new ControllerDefinition(this.project, filename)
 
       simple(ast as any, {
+        ImportDeclaration(node: any): void {
+          node.specifiers.map((specifier: any) => {
+            importStatements.push({
+              originalName: specifier.imported?.name,
+              importedName: specifier.local.name,
+              source: node.source.value
+            })
+          })
+        },
+
+        ClassDeclaration(node: any): void {
+          const superClass = node.superClass.name
+          const importStatement = importStatements.find(i => i.importedName === superClass)
+
+          if (importStatement) {
+            controller.parent = {
+              constant: superClass,
+              package: importStatement.source,
+              type: (importStatement.source === "@hotwired/stimulus" && importStatement.originalName === "Controller") ? "default" : "import",
+            }
+          } else {
+            controller.parent = {
+              constant: node.superClass.name,
+              type: "unknown",
+            }
+          }
+        },
+
         MethodDefinition(node: any): void {
           if (node.kind === "method") {
             const methodName = node.key.name

--- a/src/parser.ts
+++ b/src/parser.ts
@@ -5,6 +5,12 @@ import { Project } from "./project"
 import { ControllerDefinition, defaultValuesForType } from "./controller_definition"
 import { NodeElement, PropertyValue } from "./types"
 
+type ImportStatement = {
+  originalName?: string
+  importedName: string
+  source: string
+}
+
 type NestedArray<T> = T | NestedArray<T>[]
 type NestedObject<T> = {
   [k: string]: T | NestedObject<T>
@@ -29,7 +35,7 @@ export class Parser {
 
   parseController(code: string, filename: string) {
     try {
-      const importStatements = []
+      const importStatements: ImportStatement[] = []
       const ast = this.parse(code, filename)
       const controller = new ControllerDefinition(this.project, filename)
 

--- a/test/parser.controller.parent.test.ts
+++ b/test/parser.controller.parent.test.ts
@@ -1,0 +1,120 @@
+import { expect, test, describe } from "vitest"
+import { Project, Parser } from "../src"
+
+const project = new Project(process.cwd())
+const parser = new Parser(project)
+
+describe("@hotwired/stimulus Controller", () => {
+  test("parse parent", () => {
+    const code = `
+      import { Controller } from "@hotwired/stimulus"
+
+      export default class extends Controller {}
+    `
+    const controller = parser.parseController(code, "parent_controller.js")
+
+    expect(controller.parent.constant).toEqual("Controller")
+    expect(controller.parent.type).toEqual("default")
+    expect(controller.parent.package).toEqual("@hotwired/stimulus")
+    expect(controller.parent.definition).toEqual(undefined)
+    expect(controller.parent.identifier).toEqual(undefined)
+    expect(controller.parent.controllerFile).toEqual(undefined)
+  })
+
+  test("parse parent with import alias", () => {
+    const code = `
+      import { Controller as StimulusController } from "@hotwired/stimulus"
+
+      export default class extends StimulusController {}
+    `
+    const controller = parser.parseController(code, "parent_controller.js")
+
+    expect(controller.parent.constant).toEqual("StimulusController")
+    expect(controller.parent.type).toEqual("default")
+    expect(controller.parent.package).toEqual("@hotwired/stimulus")
+    expect(controller.parent.definition).toEqual(undefined)
+    expect(controller.parent.parent).toEqual(undefined)
+    expect(controller.parent.identifier).toEqual(undefined)
+    expect(controller.parent.controllerFile).toEqual(undefined)
+  })
+})
+
+describe("with controller in same file", () => {
+  test("parse parent", () => {
+    const code = `
+      import { Controller } from "@hotwired/stimulus"
+
+      class AbstractController extends Controller {}
+
+      export default class extends AbstractController {}
+    `
+    const controller = parser.parseController(code, "parent_controller.js")
+
+    expect(controller.parent.constant).toEqual("AbstractController")
+    expect(controller.parent.type).toEqual("unknown")
+    expect(controller.parent.package).toEqual(undefined)
+    expect(controller.parent.definition).toEqual(undefined)
+    expect(controller.parent.parent).toEqual(undefined)
+    expect(controller.parent.identifier).toEqual(undefined)
+    expect(controller.parent.controllerFile).toEqual(undefined)
+    // expect(controller.parent.controllerFile).toEqual("app/javascript/controllers/parent_controller.js")
+  })
+})
+
+describe("with controller from other file", () => {
+  test("parse parent", () => {
+    const code = `
+      import ApplicationController from "./application_controller"
+
+      export default class extends ApplicationController {}
+    `
+    const controller = parser.parseController(code, "parent_controller.js")
+
+    expect(controller.parent.constant).toEqual("ApplicationController")
+    expect(controller.parent.type).toEqual("import")
+    expect(controller.parent.package).toEqual("./application_controller")
+    expect(controller.parent.definition).toEqual(undefined)
+    expect(controller.parent.parent).toEqual(undefined)
+    expect(controller.parent.identifier).toEqual(undefined)
+    expect(controller.parent.controllerFile).toEqual(undefined)
+    // expect(controller.parent.controllerFile).toEqual("app/javascript/controllers/application_controller.js")
+  })
+})
+
+describe("with controller from stimulus package", () => {
+  test("parse parent with default import", () => {
+    const code = `
+      import SomeController from "some-package"
+
+      export default class extends SomeController {}
+    `
+    const controller = parser.parseController(code, "parent_controller.js")
+
+    expect(controller.parent.constant).toEqual("SomeController")
+    expect(controller.parent.type).toEqual("import")
+    expect(controller.parent.package).toEqual("some-package")
+    expect(controller.parent.definition).toEqual(undefined)
+    expect(controller.parent.parent).toEqual(undefined)
+    expect(controller.parent.identifier).toEqual(undefined)
+    expect(controller.parent.controllerFile).toEqual(undefined)
+    // expect(controller.parent.controllerFile).toEqual("some-package/dist/some_controller.js")
+  })
+
+  test("parse parent with regular import", () => {
+    const code = `
+      import { SomeController } from "some-package"
+
+      export default class extends SomeController {}
+    `
+    const controller = parser.parseController(code, "parent_controller.js")
+
+    expect(controller.parent.constant).toEqual("SomeController")
+    expect(controller.parent.type).toEqual("import")
+    expect(controller.parent.package).toEqual("some-package")
+    expect(controller.parent.definition).toEqual(undefined)
+    expect(controller.parent.parent).toEqual(undefined)
+    expect(controller.parent.identifier).toEqual(undefined)
+    expect(controller.parent.controllerFile).toEqual(undefined)
+    // expect(controller.parent.controllerFile).toEqual("some-package/dist/some_controller.js")
+  })
+})


### PR DESCRIPTION
This pull request adds a `parent` field on the `ControllerDefinition` class.

When parsing a controller it analyzes the parent class the controller is extending from. Given this basic controller:

```js
import { Controller } from "@hotwired/stimulus"

export default class extends Controller {
  // ...
}
```

We get this:
```js
const controller = parser.parseController(code, "parent_controller.js")

controller.parent.constant
// => "Controller"

controller.parent.type
// => "default"

controller.parent.package
// => "@hotwired/stimulus"
```

