### PR TITLE
Add AST Builder and Stimulus Builder utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "minimatch": "^9.0.3",
     "path": "^0.12.7",
     "rimraf": "^5.0.5",
+    "source-map": "^0.7.4",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",
     "typescript": "^5.3.3",

--- a/package.json
+++ b/package.json
@@ -22,12 +22,14 @@
     "@hotwired/stimulus-webpack-helpers": "^1.0.1",
     "@typescript-eslint/typescript-estree": "^6.21.0",
     "acorn-walk": "^8.3.1",
+    "astring": "^1.8.6",
     "fs": "^0.0.1-security",
     "glob": "^10.3.10"
   },
   "devDependencies": {
     "@hotwired/stimulus": "^3.2.2",
     "@types/node": "^20.10.5",
+    "dedent": "^1.5.1",
     "minimatch": "^9.0.3",
     "path": "^0.12.7",
     "rimraf": "^5.0.5",

--- a/src/util/ast_builder.ts
+++ b/src/util/ast_builder.ts
@@ -1,0 +1,192 @@
+import * as Acorn from "acorn"
+
+const node: Acorn.Node = {
+  type: "Node",
+  start: 0,
+  end: 0,
+  range: [0, 0],
+  loc: {
+    start: {
+      line: 0,
+      column: 0
+    },
+    end: {
+      line: 0,
+      column: 0
+    }
+  }
+}
+
+export * from "./stimulus_builder"
+export { generate } from "astring"
+
+export function Program(body: (Acorn.Statement|Acorn.ModuleDeclaration)[] = []): Acorn.Program {
+  return {
+    ...node,
+    type: "Program",
+    sourceType: "module",
+    body,
+  }
+}
+
+export function ClassBody(body: (Acorn.MethodDefinition | Acorn.PropertyDefinition | Acorn.StaticBlock)[] = []): Acorn.ClassBody {
+  return {
+    ...node,
+    type: "ClassBody",
+    body
+  }
+}
+
+export function ClassDeclaration(id: Acorn.Identifier | null, superClass?: Acorn.Identifier, body?: (Acorn.MethodDefinition | Acorn.PropertyDefinition | Acorn.StaticBlock)[]): Acorn.ClassDeclaration | Acorn.AnonymousClassDeclaration {
+  return {
+    ...node,
+    type: "ClassDeclaration",
+    body: ClassBody(body),
+    superClass,
+    id,
+  }
+}
+
+export function ImportSpecifier(imported: Acorn.Identifier, local?: Acorn.Identifier): Acorn.ImportSpecifier {
+  return {
+    ...node,
+    type: "ImportSpecifier",
+    local: local || imported,
+    imported,
+  }
+}
+
+export function ImportDeclaration(specifiers: Acorn.ImportSpecifier[], source: Acorn.Literal): Acorn.ImportDeclaration {
+  return {
+    ...node,
+    type: "ImportDeclaration",
+    source,
+    specifiers,
+  }
+}
+
+export function ExportDefaultDeclaration(declaration: Acorn.ClassDeclaration | Acorn.AnonymousClassDeclaration): Acorn.ExportDefaultDeclaration {
+  return {
+    ...node,
+    type: "ExportDefaultDeclaration",
+    declaration,
+  }
+}
+
+export function Literal(value: string): Acorn.Literal {
+  return {
+    ...node,
+    type: "Literal",
+    raw: `"${value}"`,
+    value,
+  }
+}
+
+export function Identifier(name: string): Acorn.Identifier {
+  return {
+    ...node,
+    type: "Identifier",
+    name,
+  }
+}
+
+export function ArrayExpression(elements: Acorn.Literal[]): Acorn.ArrayExpression {
+  return {
+    ...node,
+    type: "ArrayExpression",
+    elements
+  }
+}
+
+export function Property(key: Acorn.Expression, value: Acorn.Expression): Acorn.Property {
+  return {
+    ...node,
+    type: "Property",
+    kind: "init",
+    method: false,
+    shorthand: false,
+    computed: false,
+    key,
+    value,
+  }
+}
+
+export function ObjectExpression(properties: Acorn.Property[]): Acorn.ObjectExpression {
+  return {
+    ...node,
+    type: "ObjectExpression",
+    properties,
+  }
+}
+
+export function PropertyDefinition(key: Acorn.Expression, value: Acorn.Expression, staticValue: boolean = true): Acorn.PropertyDefinition {
+  return {
+    ...node,
+    type: "PropertyDefinition",
+    computed: false,
+    static: staticValue,
+    key,
+    value,
+  }
+}
+
+export function MethodDefinition(key: Acorn.Expression, value: Acorn.FunctionExpression): Acorn.MethodDefinition {
+  return {
+    ...node,
+    type: "MethodDefinition",
+    computed: false,
+    kind: "method",
+    static: false,
+    key,
+    value,
+  }
+}
+
+export function MemberExpression(object: Acorn.Identifier, property: Acorn.Identifier): Acorn.MemberExpression {
+  return {
+    ...node,
+    type: "MemberExpression",
+    computed: false,
+    optional: false,
+    object,
+    property,
+  }
+}
+
+export function CallExpression(callee: Acorn.MemberExpression, args: (Acorn.Expression | Acorn.SpreadElement)[] = []): Acorn.CallExpression {
+  return  {
+    ...node,
+    type: "CallExpression",
+    optional: false,
+    arguments: args,
+    callee
+  }
+}
+
+export function ExpressionStatement(expression: Acorn.Expression): Acorn.ExpressionStatement {
+  return {
+    ...node,
+    type: "ExpressionStatement",
+    expression
+  }
+}
+
+export function BlockStatement(body: Acorn.Statement[]): Acorn.BlockStatement {
+  return {
+    ...node,
+    type: "BlockStatement",
+    body,
+  }
+}
+
+export function FunctionExpression(params: Acorn.Pattern[] = [], body: Acorn.BlockStatement): Acorn.FunctionExpression {
+  return {
+    ...node,
+    type: "FunctionExpression",
+    async: false,
+    generator: false,
+    expression: false,
+    params,
+    body
+  }
+}

--- a/src/util/index.ts
+++ b/src/util/index.ts
@@ -1,0 +1,1 @@
+export * as builder from "./ast_builder"

--- a/src/util/stimulus_builder.ts
+++ b/src/util/stimulus_builder.ts
@@ -1,0 +1,88 @@
+import * as Acorn from "acorn"
+
+import {
+  ArrayExpression,
+  BlockStatement,
+  CallExpression,
+  ClassDeclaration,
+  ExpressionStatement,
+  FunctionExpression,
+  Identifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  Literal,
+  MemberExpression,
+  MethodDefinition,
+  ObjectExpression,
+  Property,
+  PropertyDefinition,
+} from "./ast_builder"
+
+export function StimulusImport(): Acorn.ImportDeclaration {
+  const importSpecifier = ImportSpecifier(
+    Identifier("Controller"),
+    Identifier("Controller")
+  )
+
+  return ImportDeclaration(
+    [importSpecifier],
+    Literal("@hotwired/stimulus")
+  )
+}
+
+export function StimulusClassDeclaration(className?: string, superClass: string|undefined = "Controller"): Acorn.ClassDeclaration | Acorn.AnonymousClassDeclaration {
+  return ClassDeclaration(
+    className ? Identifier(className) : null,
+    superClass ? Identifier(superClass) : undefined,
+  )
+}
+
+export function EmptyMethodDefinition(key: string): Acorn.MethodDefinition {
+  const memberExpression = MemberExpression(Identifier("console"), Identifier("log"))
+  const callArguments = [Literal(key), Identifier("event")]
+  const callExpression = CallExpression(memberExpression, callArguments)
+
+  const blockStatement = BlockStatement([ExpressionStatement(callExpression)])
+  const functionExpression = FunctionExpression([Identifier("event")], blockStatement)
+
+  return MethodDefinition(Identifier(key), functionExpression)
+}
+
+export function TargetsProperty(...literals: string[]): Acorn.PropertyDefinition {
+  return PropertyDefinition(
+    Identifier("targets"),
+    ArrayExpression(
+      literals.map(literal => Literal(literal))
+    )
+  )
+}
+
+export function ClassesProperty(...literals: string[]): Acorn.PropertyDefinition {
+  return PropertyDefinition(
+    Identifier("classes"),
+    ArrayExpression(
+      literals.map(literal => Literal(literal))
+    )
+  )
+}
+
+export function ValuesProperty(...properties: ([string[], string[]])): Acorn.PropertyDefinition {
+  const objectProperties = properties.map(props => {
+    if (props.length === 2) {
+      return Property(Identifier(props[0]), Identifier(props[1]))
+    }
+
+    return Property(
+      Identifier(props[0]),
+      ObjectExpression([
+        Property(Identifier("type"), Identifier(props[1])),
+        Property(Identifier("default"), Literal(props[2])),
+      ])
+    )
+  })
+
+  return PropertyDefinition(
+    Identifier("values"),
+    ObjectExpression(objectProperties)
+  )
+}

--- a/test/util/ast_builder.test.ts
+++ b/test/util/ast_builder.test.ts
@@ -1,4 +1,3 @@
-import dedent from "dedent"
 import { describe, test, expect } from "vitest"
 import * as builder from "../../src/util/ast_builder"
 

--- a/test/util/ast_builder.test.ts
+++ b/test/util/ast_builder.test.ts
@@ -1,0 +1,17 @@
+import dedent from "dedent"
+import { describe, test, expect } from "vitest"
+import * as builder from "../../src/util/ast_builder"
+
+describe("util", () => {
+  describe("ast_builder", () => {
+    test("Program", () => {
+      expect(builder.generate(builder.Program())).toEqual("")
+    })
+
+    test("ImportDeclaration", () => {
+      expect(builder.generate(builder.ImportDeclaration([], builder.Literal("a")))).toEqual(`import "a";`)
+      expect(builder.generate(builder.ImportDeclaration([builder.ImportSpecifier(builder.Identifier("A"))], builder.Literal("B")))).toEqual(`import {A} from "B";`)
+      expect(builder.generate(builder.ImportDeclaration([builder.ImportSpecifier(builder.Identifier("A"), builder.Identifier("B"))], builder.Literal("C")))).toEqual(`import {A as B} from "C";`)
+    })
+  })
+})

--- a/test/util/stimulus_builder.test.ts
+++ b/test/util/stimulus_builder.test.ts
@@ -1,0 +1,119 @@
+import dedent from "dedent"
+import { describe, test, expect } from "vitest"
+
+import * as builder from "../../src/util/ast_builder"
+
+describe("util", () => {
+  describe("stimulus_builder", () => {
+    test("StimulusImport", () => {
+      expect(builder.generate(builder.StimulusImport())).toEqual(`import {Controller} from "@hotwired/stimulus";`)
+    })
+
+    test("StimulusClassDeclaration", () => {
+      expect(builder.generate(builder.StimulusClassDeclaration())).toEqual(`class extends Controller {}`)
+      expect(builder.generate(builder.StimulusClassDeclaration("HelloController"))).toEqual(`class HelloController extends Controller {}`)
+      expect(builder.generate(builder.StimulusClassDeclaration("HelloController", "ApplicationController"))).toEqual(`class HelloController extends ApplicationController {}`)
+    })
+
+    test("EmptyMethodDefinition", () => {
+      expect(builder.generate(builder.EmptyMethodDefinition("connect"))).toEqual(dedent`
+        connect(event) {
+          console.log("connect", event);
+        }
+      `)
+    })
+
+    test("TargetsProperty", () => {
+      expect(builder.generate(builder.TargetsProperty())).toEqual(dedent`
+        static targets = [];
+      `)
+
+      expect(builder.generate(builder.TargetsProperty("one"))).toEqual(dedent`
+        static targets = ["one"];
+      `)
+
+      expect(builder.generate(builder.TargetsProperty("one", "two"))).toEqual(dedent`
+        static targets = ["one", "two"];
+      `)
+    })
+
+    test("ClassesProperty", () => {
+      expect(builder.generate(builder.ClassesProperty())).toEqual(dedent`
+        static classes = [];
+      `)
+
+      expect(builder.generate(builder.ClassesProperty("one"))).toEqual(dedent`
+        static classes = ["one"];
+      `)
+
+      expect(builder.generate(builder.ClassesProperty("one", "two"))).toEqual(dedent`
+        static classes = ["one", "two"];
+      `)
+    })
+
+    test("ValuesProperty", () => {
+      expect(builder.generate(builder.ValuesProperty())).toEqual(dedent`
+        static values = {};
+      `)
+
+      expect(builder.generate(builder.ValuesProperty(["open", "Boolean"]))).toEqual(dedent`
+        static values = {
+          open: Boolean
+        };
+      `)
+
+      expect(builder.generate(builder.ValuesProperty(["url", "String", "/path"]))).toEqual(dedent`
+        static values = {
+          url: {
+            type: String,
+            default: "/path"
+          }
+        };
+      `)
+    })
+
+    test("generates full controller file", () => {
+      const program = builder.Program()
+      const controller = builder.StimulusClassDeclaration()
+
+      program.body = [
+        builder.StimulusImport(),
+        builder.ExportDefaultDeclaration(controller)
+      ]
+
+      controller.body.body = [
+        builder.TargetsProperty("input", "output"),
+        builder.ClassesProperty("loading", "loaded"),
+
+        builder.ValuesProperty(
+          ["open", "Boolean"],
+          ["url", "String", "/path"]
+        ),
+
+        builder.EmptyMethodDefinition("connect"),
+        builder.EmptyMethodDefinition("disconnect"),
+      ]
+
+      expect(builder.generate(program)).toContain(dedent`
+        import {Controller} from "@hotwired/stimulus";
+        export default class extends Controller {
+          static targets = ["input", "output"];
+          static classes = ["loading", "loaded"];
+          static values = {
+            open: Boolean,
+            url: {
+              type: String,
+              default: "/path"
+            }
+          };
+          connect(event) {
+            console.log("connect", event);
+          }
+          disconnect(event) {
+            console.log("disconnect", event);
+          }
+        }
+      `)
+    })
+  })
+})

--- a/yarn.lock
+++ b/yarn.lock
@@ -417,6 +417,11 @@ assertion-error@^1.1.0:
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
   integrity sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==
 
+astring@^1.8.6:
+  version "1.8.6"
+  resolved "https://registry.yarnpkg.com/astring/-/astring-1.8.6.tgz#2c9c157cf1739d67561c56ba896e6948f6b93731"
+  integrity sha512-ISvCdHdlTDlH5IpxQJIex7BWBywFWgjJSVdwst+/iQCoEYnyOaQ95+X1JGshuBjGp6nxKUy1jMgE3zPqN7fQdg==
+
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
@@ -493,6 +498,11 @@ debug@^4.3.4:
   integrity sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==
   dependencies:
     ms "2.1.2"
+
+dedent@^1.5.1:
+  version "1.5.1"
+  resolved "https://registry.yarnpkg.com/dedent/-/dedent-1.5.1.tgz#4f3fc94c8b711e9bb2800d185cd6ad20f2a90aff"
+  integrity sha512-+LxW+KLWxu3HW3M2w2ympwtqPrqYRzU8fqi6Fhd18fBALe15blJPI/I4+UHveMVG6lJqB4JNd4UG0S5cnVHwIg==
 
 deep-eql@^4.1.3:
   version "4.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1040,6 +1040,11 @@ source-map-js@^1.0.2:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.0.2.tgz#adbc361d9c62df380125e7f161f71c826f1e490c"
   integrity sha512-R0XvVJ9WusLiqTCEiGCmICCMplcCkIwwR11mOSD9CR5u+IXYdiseeEuXCVAjS54zqwkLcPNnmU4OeJ6tUrWhDw==
 
+source-map@^0.7.4:
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.7.4.tgz#a9bbe705c9d8846f4e08ff6765acf0f1b0898656"
+  integrity sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==
+
 stackback@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/stackback/-/stackback-0.0.2.tgz#1ac8a0d9483848d1695e418b6d031a3c3ce68e3b"


### PR DESCRIPTION
This pull request adds builders that can be used to generate an ESTree-compliant AST. It also adds utilities which are build on top of low-level AST Builder utilities for building Stimulus Controller files.

**Example:**
```js
import { builder } from "stimulus-parser"

const program = builder.Program()
const controller = builder.StimulusClassDeclaration()

program.body = [
  builder.StimulusImport(),
  builder.ExportDefaultDeclaration(controller)
]

controller.body.body = [
  builder.TargetsProperty("input", "output"),
  builder.ClassesProperty("loading", "loaded"),

  builder.ValuesProperty(
    ["open", "Boolean"],
    ["url", "String", "/path"]
  ),

  builder.EmptyMethodDefinition("connect"),
  builder.EmptyMethodDefinition("disconnect"),
]

console.log(builder.generate(program))
```

**Outputs:**
```js
import {Controller} from "@hotwired/stimulus";
export default class extends Controller {
  static targets = ["input", "output"];
  static classes = ["loading", "loaded"];
  static values = {
    open: Boolean,
    url: {
      type: String,
      default: "/path"
    }
  };
  connect(event) {
    console.log("connect", event);
  }
  disconnect(event) {
    console.log("disconnect", event);
  }
}
```