### PR TITLE
Remove `postinstall` script

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,6 @@
     "clean": "rimraf dist",
     "prerelease": "yarn build",
     "install:fixtures": "node scripts/setupFixtures.mjs",
-    "postinstall": "yarn install:fixtures",
     "pretest": "yarn install:fixtures",
     "test": "vitest"
   },


### PR DESCRIPTION
This pull request removes the `postinstall` script as it was causing trouble when installing the `stimulus-parser` package in a project:

```
❯ yarn add stimulus-parser
yarn add v1.22.19
[1/5] 🔍  Validating package.json...
[2/5] 🔍  Resolving packages...
[3/5] 🚚  Fetching packages...
[4/5] 🔗  Linking dependencies...
[5/5] 🔨  Building fresh packages...
error node_modules/stimulus-parser: Command failed.
Exit code: 1
Command: yarn install:fixtures
Arguments:
Directory: node_modules/stimulus-parser
Output:
yarn run v1.22.19
$ node scripts/setupFixtures.mjs
node:internal/modules/cjs/loader:1147
  throw err;
  ^

Error: Cannot find module 'node_modules/stimulus-parser/scripts/setupFixtures.mjs'
    at Module._resolveFilename (node:internal/modules/cjs/loader:1144:15)
    at Module._load (node:internal/modules/cjs/loader:985:27)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:135:12)
    at node:internal/main/run_main_module:28:49 {
  code: 'MODULE_NOT_FOUND',
  requireStack: []
}

Node.js v20.11.1
error Command failed with exit code 1.
info Visit https://yarnpkg.com/en/docs/cli/add for documentation about this command.
```