### PR TITLE
Parse `ClassExpression` nodes as `ClassDeclaration`

### DIFF
--- a/src/source_file.ts
+++ b/src/source_file.ts
@@ -317,7 +317,10 @@ export class SourceFile {
       },
 
       ClassExpression: node => {
-        this.classDeclarations.push(new ClassDeclaration(this, undefined, node))
+        const className = ast.extractIdentifier(node.id)
+        const classDeclaration = new ClassDeclaration(this, className, node)
+
+        this.classDeclarations.push(classDeclaration)
       },
 
       VariableDeclaration: node => {

--- a/src/source_file.ts
+++ b/src/source_file.ts
@@ -316,6 +316,10 @@ export class SourceFile {
         this.classDeclarations.push(classDeclaration)
       },
 
+      ClassExpression: node => {
+        this.classDeclarations.push(new ClassDeclaration(this, undefined, node))
+      },
+
       VariableDeclaration: node => {
         node.declarations.forEach(declaration => {
           if (declaration.type !== "VariableDeclarator") return

--- a/test/source_file/class_declarations.test.ts
+++ b/test/source_file/class_declarations.test.ts
@@ -178,6 +178,33 @@ describe("SourceFile", () => {
       expect(something.superClass).toBeInstanceOf(StimulusControllerClassDeclaration)
     })
 
+    test("anonymous class (ClassExpression) as argument to function call", async () => {
+      const code = dedent`
+        import { Controller } from "@hotwired/stimulus"
+
+        application.register(class extends Controller {
+          connect() {}
+          disconnect() {}
+        })
+      `
+
+      const sourceFile = new SourceFile(project, "abc.js", code)
+      project.projectFiles.push(sourceFile)
+
+      await project.analyze()
+
+      expect(sourceFile.classDeclarations).toHaveLength(1)
+
+      const something = sourceFile.classDeclarations[0]
+
+      expect(something).toBeDefined()
+      expect(something.isStimulusDescendant).toBeTruthy()
+      expect(something.superClass).toBeDefined()
+      expect(something.superClass.isStimulusDescendant).toBeTruthy()
+      expect(something.superClass).toBeInstanceOf(StimulusControllerClassDeclaration)
+      expect(something.controllerDefinition.actionNames).toEqual(["connect", "disconnect"])
+    })
+
     test("named class with superclass from import via second class", async () => {
       const code = dedent`
         import { Controller } from "@hotwired/stimulus"

--- a/test/source_file/class_declarations.test.ts
+++ b/test/source_file/class_declarations.test.ts
@@ -205,6 +205,34 @@ describe("SourceFile", () => {
       expect(something.controllerDefinition.actionNames).toEqual(["connect", "disconnect"])
     })
 
+    test("named class (ClassExpression) as argument to function call", async () => {
+      const code = dedent`
+        import { Controller } from "@hotwired/stimulus"
+
+        application.register(class Something extends Controller {
+          connect() {}
+          disconnect() {}
+        })
+      `
+
+      const sourceFile = new SourceFile(project, "abc.js", code)
+      project.projectFiles.push(sourceFile)
+
+      await project.analyze()
+
+      expect(sourceFile.classDeclarations).toHaveLength(1)
+
+      const something = sourceFile.classDeclarations[0]
+
+      expect(something).toBeDefined()
+      expect(something.className).toEqual("Something")
+      expect(something.isStimulusDescendant).toBeTruthy()
+      expect(something.superClass).toBeDefined()
+      expect(something.superClass.isStimulusDescendant).toBeTruthy()
+      expect(something.superClass).toBeInstanceOf(StimulusControllerClassDeclaration)
+      expect(something.controllerDefinition.actionNames).toEqual(["connect", "disconnect"])
+    })
+
     test("named class with superclass from import via second class", async () => {
       const code = dedent`
         import { Controller } from "@hotwired/stimulus"


### PR DESCRIPTION
This pull requests adds support for parsing `ClassExpression` nodes as `ClassDeclaration`s.

Resolves https://github.com/marcoroth/stimulus-parser/issues/72