### PR TITLE
Improve `NodeModule` lifecycle

### DIFF
--- a/src/node_module.ts
+++ b/src/node_module.ts
@@ -16,6 +16,8 @@ interface NodeModuleArgs {
 }
 
 export class NodeModule {
+  public isAnalyzed: boolean = false
+
   public readonly project: Project
   public readonly name: string
   public readonly path: string
@@ -42,18 +44,22 @@ export class NodeModule {
 
   async initialize() {
     if (shouldIgnore(this.name)) return
+    if (this.isAnalyzed) return
 
     await Promise.allSettled(this.sourceFiles.map(sourceFile => sourceFile.initialize()))
   }
 
   async analyze() {
     if (shouldIgnore(this.name)) return
+    if (this.isAnalyzed) return
 
     const referencedFilePaths = this.sourceFiles.flatMap(s => s.importDeclarations.filter(i => i.isRelativeImport).map(i => i.resolvedRelativePath))
     const referencedSourceFiles = this.sourceFiles.filter(s => referencedFilePaths.includes(s.path))
 
     await Promise.allSettled(referencedSourceFiles.map(sourceFile => sourceFile.analyze()))
     await Promise.allSettled(this.sourceFiles.map(sourceFile => sourceFile.analyze()))
+
+    this.isAnalyzed = true
   }
 
   async refresh() {

--- a/src/packages.ts
+++ b/src/packages.ts
@@ -71,7 +71,7 @@ export async function analyzePackage(project: Project, name: string) {
 
   const packagePath = path.join(nodeModulesPath, name, "package.json")
 
-  return await anylzePackagePath(project, packagePath)
+  return await analyzePackagePath(project, packagePath)
 }
 
 export function shouldIgnore(name: string): boolean {
@@ -80,7 +80,7 @@ export function shouldIgnore(name: string): boolean {
   return ignoredPackageNamespaces.some(namespace => name.includes(namespace))
 }
 
-export async function anylzePackagePath(project: Project, packagePath: string) {
+export async function analyzePackagePath(project: Project, packagePath: string) {
   const packageJSON = await parsePackageJSON(packagePath)
   const packageName = packageJSON.name
 
@@ -109,6 +109,6 @@ export async function analyzeAll(project: Project) {
   ]
 
   await Promise.allSettled(
-    packages.map(packagePath => anylzePackagePath(project, packagePath))
+    packages.map(packagePath => analyzePackagePath(project, packagePath))
   )
 }

--- a/src/project.ts
+++ b/src/project.ts
@@ -174,6 +174,8 @@ export class Project {
     if (!projectFile) return
 
     await projectFile.refresh()
+
+    return projectFile
   }
 
 
@@ -196,7 +198,7 @@ export class Project {
         await analyzePackage(this, packageName)
       )
 
-      if (nodeModule) {
+      if (nodeModule && !nodeModule.isAnalyzed) {
         await nodeModule.initialize()
       }
     })
@@ -210,8 +212,16 @@ export class Project {
   }
 
   async analyzeAllDetectedModules() {
-    await Promise.allSettled(this.detectedNodeModules.map(module => module.initialize()))
-    await Promise.allSettled(this.detectedNodeModules.map(module => module.analyze()))
+    const notAnalyzed = this.detectedNodeModules.filter(module => !module.isAnalyzed)
+
+    await Promise.allSettled(notAnalyzed.map(module => module.initialize()))
+    await Promise.allSettled(notAnalyzed.map(module => module.analyze()))
+  }
+
+  async refreshAllDetectedModules() {
+    const analyzed = this.detectedNodeModules.filter(module => module.isAnalyzed)
+
+    await Promise.allSettled(analyzed.map(module => module.refresh()))
   }
 
   async analyzeStimulusApplicationFile() {

--- a/test/node_module/lifecycle.test.ts
+++ b/test/node_module/lifecycle.test.ts
@@ -1,0 +1,104 @@
+import { describe, beforeEach, test, expect } from "vitest"
+import { setupProject } from "../helpers/setup"
+import { NodeModule } from "../../src/node_module"
+
+let project = setupProject("app")
+
+describe("Node Module", () => {
+  beforeEach(() => {
+    project = setupProject("app")
+  })
+
+  test("analyze", async () => {
+    const nodeModule = await NodeModule.forProject(project, "tailwindcss-stimulus-components")
+    expect(nodeModule.isAnalyzed).toEqual(false)
+    expect(nodeModule.sourceFiles).toHaveLength(11)
+    expect(nodeModule.sourceFiles.filter(file => file.isAnalyzed)).toHaveLength(0)
+
+    await nodeModule.initialize()
+    await nodeModule.analyze()
+
+    expect(nodeModule.isAnalyzed).toEqual(true)
+    expect(nodeModule.sourceFiles).toHaveLength(11)
+    expect(nodeModule.sourceFiles.filter(file => file.isAnalyzed)).toHaveLength(11)
+  })
+
+  test("initialize more than once", async () => {
+    const nodeModule = await NodeModule.forProject(project, "tailwindcss-stimulus-components")
+    expect(nodeModule.isAnalyzed).toEqual(false)
+    expect(nodeModule.sourceFiles).toHaveLength(11)
+    expect(nodeModule.sourceFiles.filter(file => file.isAnalyzed)).toHaveLength(0)
+
+    await nodeModule.initialize()
+    await nodeModule.analyze()
+
+    await nodeModule.initialize()
+    await nodeModule.analyze()
+
+    await nodeModule.initialize()
+    await nodeModule.analyze()
+
+    expect(nodeModule.isAnalyzed).toEqual(true)
+    expect(nodeModule.sourceFiles).toHaveLength(11)
+    expect(nodeModule.sourceFiles.filter(file => file.isAnalyzed)).toHaveLength(11)
+  })
+
+  test("refreshes", async () => {
+    const nodeModule = await NodeModule.forProject(project, "tailwindcss-stimulus-components")
+
+    expect(nodeModule.isAnalyzed).toEqual(false)
+    expect(project.relativePath(nodeModule.entrypointSourceFile.path)).toEqual("node_modules/tailwindcss-stimulus-components/src/index.js")
+    expect(nodeModule.entrypointSourceFile.importDeclarations).toHaveLength(0)
+    expect(nodeModule.entrypointSourceFile.exportDeclarations).toHaveLength(0)
+    expect(nodeModule.sourceFiles).toHaveLength(11)
+    expect(nodeModule.sourceFiles.filter(file => file.isAnalyzed)).toHaveLength(0)
+
+    await nodeModule.initialize()
+    await nodeModule.analyze()
+    await nodeModule.refresh()
+
+    expect(nodeModule.isAnalyzed).toEqual(true)
+    expect(nodeModule.entrypointSourceFile.importDeclarations).toHaveLength(0)
+    expect(nodeModule.entrypointSourceFile.exportDeclarations).toHaveLength(9)
+    expect(nodeModule.sourceFiles).toHaveLength(11)
+    expect(nodeModule.sourceFiles.filter(file => file.isAnalyzed)).toHaveLength(11)
+
+    await nodeModule.refresh()
+
+    expect(nodeModule.isAnalyzed).toEqual(true)
+    expect(nodeModule.entrypointSourceFile.importDeclarations).toHaveLength(0)
+    expect(nodeModule.entrypointSourceFile.exportDeclarations).toHaveLength(9)
+    expect(nodeModule.sourceFiles).toHaveLength(11)
+    expect(nodeModule.sourceFiles.filter(file => file.isAnalyzed)).toHaveLength(11)
+  })
+
+  test("entrypoint file exports", async () => {
+    const nodeModule = await NodeModule.forProject(project, "tailwindcss-stimulus-components")
+
+    expect(nodeModule.isAnalyzed).toEqual(false)
+    expect(project.relativePath(nodeModule.entrypointSourceFile.path)).toEqual("node_modules/tailwindcss-stimulus-components/src/index.js")
+    expect(nodeModule.entrypointSourceFile.importDeclarations).toHaveLength(0)
+    expect(nodeModule.entrypointSourceFile.exportDeclarations).toHaveLength(0)
+
+    await nodeModule.initialize()
+    await nodeModule.analyze()
+
+    expect(nodeModule.isAnalyzed).toEqual(true)
+    expect(nodeModule.entrypointSourceFile.importDeclarations).toHaveLength(0)
+    expect(nodeModule.entrypointSourceFile.exportDeclarations).toHaveLength(9)
+
+    await nodeModule.initialize()
+    await nodeModule.analyze()
+
+    expect(nodeModule.isAnalyzed).toEqual(true)
+    expect(nodeModule.entrypointSourceFile.importDeclarations).toHaveLength(0)
+    expect(nodeModule.entrypointSourceFile.exportDeclarations).toHaveLength(9)
+
+    await nodeModule.initialize()
+    await nodeModule.analyze()
+
+    expect(nodeModule.isAnalyzed).toEqual(true)
+    expect(nodeModule.entrypointSourceFile.importDeclarations).toHaveLength(0)
+    expect(nodeModule.entrypointSourceFile.exportDeclarations).toHaveLength(9)
+  })
+})


### PR DESCRIPTION
This pull request changes the way the `NodeModule` class handles the lifecycle methods, so that they don't cause the list of SourceFiles and the list of import/exports to grow when you call `initialize()`, `analyze()` or `refresh()` repeatedly. 