### PR TITLE
Add `kind` to `ValueDefinition`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type NestedObject<T> = {
 }
 
 export type ValueDefinitionValue = string | number | bigint | boolean | object | null | undefined
-export type ValueDefinitionKind = "explicit" | "inferred" | "shorthand" | "decorator"
+export type ValueDefinitionKind = "expanded" | "inferred" | "shorthand" | "decorator"
 
 export type ValueDefinition = {
   type: string

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,12 +7,14 @@ export type NestedObject<T> = {
 }
 
 export type ValueDefinitionValue = string | number | bigint | boolean | object | null | undefined
+export type ValueDefinitionKind = "explicit" | "inferred" | "shorthand" | "decorator"
 
 export type ValueDefinition = {
   type: string
   default: ValueDefinitionValue
   keyLoc: Acorn.SourceLocation | undefined | null
   valueLoc: Acorn.SourceLocation | undefined | null
+  kind: ValueDefinitionKind
 }
 
 export type ValueDefinitionObject = { [key: string]: ValueDefinition }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,8 @@ export type ValueDefinitionValue = string | number | bigint | boolean | object |
 export type ValueDefinition = {
   type: string
   default: ValueDefinitionValue
-  keyLoc?: Acorn.SourceLocation | null
-  valueLoc?: Acorn.SourceLocation | null
+  keyLoc: Acorn.SourceLocation | undefined | null
+  valueLoc: Acorn.SourceLocation | undefined | null
 }
 
 export type ValueDefinitionObject = { [key: string]: ValueDefinition }

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -97,6 +97,7 @@ export function convertObjectExpressionToValueDefinition(objectExpression: Acorn
   return {
     type,
     default: defaultValue,
+    kind: "explicit",
     keyLoc,
     valueLoc,
   }
@@ -108,6 +109,7 @@ export function convertPropertyToValueDefinition(property: Acorn.Property): Valu
       return {
         type: property.value.name,
         default: ValueDefinition.defaultValuesForType[property.value.name],
+        kind: "shorthand",
         keyLoc: property.key.loc,
         valueLoc: property.value.loc
       }

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -97,7 +97,7 @@ export function convertObjectExpressionToValueDefinition(objectExpression: Acorn
   return {
     type,
     default: defaultValue,
-    kind: "explicit",
+    kind: "expanded",
     keyLoc,
     valueLoc,
   }

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -93,7 +93,9 @@ export function convertPropertyToValueDefinition(property: Acorn.Property): Valu
     case "Identifier":
       return {
         type: property.value.name,
-        default: ValueDefinition.defaultValuesForType[property.value.name]
+        default: ValueDefinition.defaultValuesForType[property.value.name],
+        keyLoc: property.key.loc,
+        valueLoc: property.value.loc
       }
     case "ObjectExpression":
       return convertObjectExpressionToValueDefinition(property.value)

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -11,13 +11,27 @@ export function findPropertyInProperties(_properties: (Acorn.Property | Acorn.Sp
   )
 }
 
-export function convertArrayExpression(value: Acorn.ArrayExpression): Array<string> {
+export function convertArrayExpressionToLiterals(value: Acorn.ArrayExpression): Array<ValueDefinitionValue> {
   return value.elements.map(node => {
     if (!node) return
 
     switch (node.type) {
-      case "ArrayExpression": return convertArrayExpression(node)
-      case "Literal":         return node.value?.toString()
+      case "ArrayExpression": return convertArrayExpressionToLiterals(node)
+      case "Literal":         return extractLiteral(node)
+      case "SpreadElement":   return // TODO: implement support for spreads
+      default:                return
+    }
+  })
+}
+
+export function convertArrayExpressionToStrings(value: Acorn.ArrayExpression): string[] {
+  return value.elements.map(node => {
+    if (!node) return
+
+    switch (node.type) {
+      case "ArrayExpression": return convertArrayExpressionToStrings(node)
+      case "Literal":         return node.value?.toString() ?? node.raw
+      case "Identifier":      return node.name
       case "SpreadElement":   return // TODO: implement support for spreads
       default:                return
     }
@@ -107,7 +121,7 @@ export function getDefaultValueFromNode(node?: Acorn.Expression | null) {
 
   switch (node.type) {
     case "ArrayExpression":
-      return convertArrayExpression(node)
+      return convertArrayExpressionToLiterals(node)
     case "ObjectExpression":
       return convertObjectExpression(node)
     case "Literal":

--- a/src/util/decorators.ts
+++ b/src/util/decorators.ts
@@ -85,7 +85,9 @@ export function parseValueDecorator(controllerDefinition: ControllerDefinition, 
 
   const definition: ValueDefinitionType = {
     type: type.name,
-    default: defaultValue
+    default: defaultValue,
+    keyLoc: decorator.loc,
+    valueLoc: node.loc
   }
 
   const valueDefinition = new ValueDefinition(key, definition, node as any, node.loc, "decorator")

--- a/src/util/decorators.ts
+++ b/src/util/decorators.ts
@@ -86,6 +86,7 @@ export function parseValueDecorator(controllerDefinition: ControllerDefinition, 
   const definition: ValueDefinitionType = {
     type: type.name,
     default: defaultValue,
+    kind: "decorator",
     keyLoc: decorator.loc,
     valueLoc: node.loc
   }

--- a/src/util/properties.ts
+++ b/src/util/properties.ts
@@ -9,7 +9,7 @@ export function parseStaticControllerProperties(controllerDefinition: Controller
 
   if (right.type === "ArrayExpression") {
     if (left.name === "targets") {
-      ast.convertArrayExpression(right).map(element =>
+      ast.convertArrayExpressionToStrings(right).map(element =>
         controllerDefinition.addTargetDefinition(
           new TargetDefinition(element, right, right.loc, "static")
         )
@@ -17,7 +17,7 @@ export function parseStaticControllerProperties(controllerDefinition: Controller
     }
 
     if (left.name === "classes") {
-      ast.convertArrayExpression(right).map(element =>
+      ast.convertArrayExpressionToStrings(right).map(element =>
         controllerDefinition.addClassDefinition(
           new ClassDefinition(element, right, right.loc, "static")
         )

--- a/test/parser/javascript.test.ts
+++ b/test/parser/javascript.test.ts
@@ -77,11 +77,66 @@ describe("with JS Syntax", () => {
     const controller = parseController(code, "value_controller.js")
 
     expect(controller.valueDefinitionsMap).toEqual({
-      string: { type: "String", default: "" },
-      object: { type: "Object", default: {} },
-      boolean: { type: "Boolean", default: false },
-      array: { type: "Array", default: [] },
-      number: { type: "Number", default: 0 },
+      array: {
+        type: "Array",
+        default: [],
+        keyLoc: {
+          end: { column: 9, line: 8 },
+          start: { column: 4, line: 8 },
+        },
+        valueLoc: {
+          end: { column: 16, line: 8 },
+          start: { column: 11, line: 8 },
+        },
+      },
+      boolean: {
+        type: "Boolean",
+        default: false,
+        keyLoc: {
+          end: { column: 11, line: 7 },
+          start: { column: 4, line: 7 },
+        },
+        valueLoc: {
+          end: { column: 20, line: 7 },
+          start: { column: 13, line: 7 },
+        },
+      },
+      number: {
+        type: "Number",
+        default: 0,
+        keyLoc: {
+          end: { column: 10, line: 9 },
+          start: { column: 4, line: 9 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 9 },
+          start: { column: 12, line: 9 },
+        },
+      },
+      object: {
+        type: "Object",
+        default: {},
+        keyLoc: {
+          end: { column: 10, line: 6 },
+          start: { column: 4, line: 6 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 6 },
+          start: { column: 12, line: 6 },
+        },
+      },
+      string: {
+        type: "String",
+        default: "",
+        keyLoc: {
+          end: { column: 10, line: 5 },
+          start: { column: 4, line: 5 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 5 },
+          start: { column: 12, line: 5 },
+        },
+      },
     })
   })
 

--- a/test/parser/javascript.test.ts
+++ b/test/parser/javascript.test.ts
@@ -80,6 +80,7 @@ describe("with JS Syntax", () => {
       array: {
         type: "Array",
         default: [],
+        kind: "shorthand",
         keyLoc: {
           end: { column: 9, line: 8 },
           start: { column: 4, line: 8 },
@@ -92,6 +93,7 @@ describe("with JS Syntax", () => {
       boolean: {
         type: "Boolean",
         default: false,
+        kind: "shorthand",
         keyLoc: {
           end: { column: 11, line: 7 },
           start: { column: 4, line: 7 },
@@ -104,6 +106,7 @@ describe("with JS Syntax", () => {
       number: {
         type: "Number",
         default: 0,
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 9 },
           start: { column: 4, line: 9 },
@@ -116,6 +119,7 @@ describe("with JS Syntax", () => {
       object: {
         type: "Object",
         default: {},
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 6 },
           start: { column: 4, line: 6 },
@@ -128,6 +132,7 @@ describe("with JS Syntax", () => {
       string: {
         type: "String",
         default: "",
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 5 },
           start: { column: 4, line: 5 },
@@ -158,31 +163,37 @@ describe("with JS Syntax", () => {
 
     expect(controller.valueDefinitionsMap).toEqual({
       string: {
-        type: "String", default: "string",
+        type: "String",
+        default: "string",
+        kind: "explicit",
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       object: {
         type: "Object",
         default: { object: "Object" },
+        kind: "explicit",
         valueLoc: { end: { column: 26, line: 6 }, start: { column: 20, line: 6 } },
         keyLoc: { end: { column: 18, line: 6 }, start: { column: 14, line: 6 } },
       },
       boolean: {
         type: "Boolean",
         default: true,
+        kind: "explicit",
         valueLoc: { end: { column: 28, line: 7 }, start: { column: 21, line: 7 } },
         keyLoc: { end: { column: 19, line: 7 }, start: { column: 15, line: 7 } }
       },
       array: {
         type: "Array",
         default: ["Array"],
+        kind: "explicit",
         valueLoc: { end: { column: 24, line: 8 }, start: { column: 19, line: 8 } },
         keyLoc: { end: { column: 17, line: 8 }, start: { column: 13, line: 8 } }
       },
       number: {
         type: "Number",
         default: 1,
+        kind: "explicit",
         valueLoc: { end: { column: 26, line: 9 }, start: { column: 20, line: 9 } },
         keyLoc: { end: { column: 18, line: 9 }, start: { column: 14, line: 9 } }
       },
@@ -311,12 +322,14 @@ describe("with JS Syntax", () => {
       object: {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
+        kind: "explicit",
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
+        kind: "explicit",
         valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } },
         keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } }
       },

--- a/test/parser/javascript.test.ts
+++ b/test/parser/javascript.test.ts
@@ -165,35 +165,35 @@ describe("with JS Syntax", () => {
       string: {
         type: "String",
         default: "string",
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       object: {
         type: "Object",
         default: { object: "Object" },
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 26, line: 6 }, start: { column: 20, line: 6 } },
         keyLoc: { end: { column: 18, line: 6 }, start: { column: 14, line: 6 } },
       },
       boolean: {
         type: "Boolean",
         default: true,
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 28, line: 7 }, start: { column: 21, line: 7 } },
         keyLoc: { end: { column: 19, line: 7 }, start: { column: 15, line: 7 } }
       },
       array: {
         type: "Array",
         default: ["Array"],
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 24, line: 8 }, start: { column: 19, line: 8 } },
         keyLoc: { end: { column: 17, line: 8 }, start: { column: 13, line: 8 } }
       },
       number: {
         type: "Number",
         default: 1,
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 26, line: 9 }, start: { column: 20, line: 9 } },
         keyLoc: { end: { column: 18, line: 9 }, start: { column: 14, line: 9 } }
       },
@@ -322,14 +322,14 @@ describe("with JS Syntax", () => {
       object: {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } },
         keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } }
       },

--- a/test/parser/targets.test.ts
+++ b/test/parser/targets.test.ts
@@ -99,7 +99,7 @@ describe("parse targets", () => {
     const controller = parseController(code, "target_controller.js")
 
     expect(controller.isTyped).toBeFalsy()
-    expect(controller.targetNames).toEqual(["one", "1", "3.14", "/something/", "true", "false"])
+    expect(controller.targetNames).toEqual(["one", "1", "3.14", "/something/", "true", "false", "null", "undefined"])
     expect(controller.hasErrors).toBeFalsy()
   })
 

--- a/test/parser/typescript.test.ts
+++ b/test/parser/typescript.test.ts
@@ -79,6 +79,7 @@ describe("with TS Syntax", () => {
       array: {
         type: "Array",
         default: [],
+        kind: "shorthand",
         keyLoc: {
           end: { column: 9, line: 8 },
           start: { column: 4, line: 8 },
@@ -91,6 +92,7 @@ describe("with TS Syntax", () => {
       boolean: {
         type: "Boolean",
         default: false,
+        kind: "shorthand",
         keyLoc: {
           end: { column: 11, line: 7 },
           start: { column: 4, line: 7 },
@@ -103,6 +105,7 @@ describe("with TS Syntax", () => {
       number: {
         type: "Number",
         default: 0,
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 9 },
           start: { column: 4, line: 9 },
@@ -115,6 +118,7 @@ describe("with TS Syntax", () => {
       object: {
         type: "Object",
         default: {},
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 6 },
           start: { column: 4, line: 6 },
@@ -127,6 +131,7 @@ describe("with TS Syntax", () => {
       string: {
         type: "String",
         default: "",
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 5 },
           start: { column: 4, line: 5 },
@@ -162,11 +167,40 @@ describe("with TS Syntax", () => {
     const controller = parseController(code, "value_controller.ts")
 
     expect(controller.valueDefinitionsMap).toEqual({
-      string: { type: "String", default: "string", valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } }, keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } } },
-      object: { type: "Object", default: { object: "Object" }, valueLoc: { end: { column: 26, line: 6 }, start: { column: 20, line: 6 } }, keyLoc: { end: { column: 18, line: 6 }, start: { column: 14, line: 6 } } },
-      boolean: { type: "Boolean", default: true, valueLoc: { end: { column: 28, line: 7 }, start: { column: 21, line: 7 } }, keyLoc: { end: { column: 19, line: 7 }, start: { column: 15, line: 7 } } },
-      array: { type: "Array", default: ["Array"], valueLoc: { end: { column: 24, line: 8 }, start: { column: 19, line: 8 } }, keyLoc: { end: { column: 17, line: 8 }, start: { column: 13, line: 8 } } },
-      number: { type: "Number", default: 1, valueLoc: { end: { column: 26, line: 9 }, start: { column: 20, line: 9 } }, keyLoc: { end: { column: 18, line: 9 }, start: { column: 14, line: 9 } } },
+      string: {
+        type: "String",
+        default: "string",
+        kind: "explicit",
+        valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
+        keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
+      },
+      object: {
+        type: "Object",
+        default: { object: "Object" },
+        kind: "explicit",
+        valueLoc: { end: { column: 26, line: 6 }, start: { column: 20, line: 6 } },
+        keyLoc: { end: { column: 18, line: 6 }, start: { column: 14, line: 6 } } },
+      boolean: {
+        type: "Boolean",
+        default: true,
+        kind: "explicit",
+        valueLoc: { end: { column: 28, line: 7 }, start: { column: 21, line: 7 } },
+        keyLoc: { end: { column: 19, line: 7 }, start: { column: 15, line: 7 } }
+      },
+      array: {
+        type: "Array",
+        default: ["Array"],
+        kind: "explicit",
+        valueLoc: { end: { column: 24, line: 8 }, start: { column: 19, line: 8 } },
+        keyLoc: { end: { column: 17, line: 8 }, start: { column: 13, line: 8 } }
+      },
+      number: {
+        type: "Number",
+        default: 1,
+        kind: "explicit",
+        valueLoc: { end: { column: 26, line: 9 }, start: { column: 20, line: 9 } },
+        keyLoc: { end: { column: 18, line: 9 }, start: { column: 14, line: 9 } }
+      },
     })
   })
 
@@ -264,12 +298,14 @@ describe("with TS Syntax", () => {
       object: {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
+        kind: "explicit",
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
+        kind: "explicit",
         valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } },
         keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } }
       },

--- a/test/parser/typescript.test.ts
+++ b/test/parser/typescript.test.ts
@@ -76,11 +76,66 @@ describe("with TS Syntax", () => {
     const controller = parseController(code, "value_controller.ts")
 
     expect(controller.valueDefinitionsMap).toEqual({
-      string: { type: "String", default: "" },
-      object: { type: "Object", default: {} },
-      boolean: { type: "Boolean", default: false },
-      array: { type: "Array", default: [] },
-      number: { type: "Number", default: 0 },
+      array: {
+        type: "Array",
+        default: [],
+        keyLoc: {
+          end: { column: 9, line: 8 },
+          start: { column: 4, line: 8 },
+        },
+        valueLoc: {
+          end: { column: 16, line: 8 },
+          start: { column: 11, line: 8 },
+        },
+      },
+      boolean: {
+        type: "Boolean",
+        default: false,
+        keyLoc: {
+          end: { column: 11, line: 7 },
+          start: { column: 4, line: 7 },
+        },
+        valueLoc: {
+          end: { column: 20, line: 7 },
+          start: { column: 13, line: 7 },
+        },
+      },
+      number: {
+        type: "Number",
+        default: 0,
+        keyLoc: {
+          end: { column: 10, line: 9 },
+          start: { column: 4, line: 9 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 9 },
+          start: { column: 12, line: 9 },
+        },
+      },
+      object: {
+        type: "Object",
+        default: {},
+        keyLoc: {
+          end: { column: 10, line: 6 },
+          start: { column: 4, line: 6 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 6 },
+          start: { column: 12, line: 6 },
+        },
+      },
+      string: {
+        type: "String",
+        default: "",
+        keyLoc: {
+          end: { column: 10, line: 5 },
+          start: { column: 4, line: 5 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 5 },
+          start: { column: 12, line: 5 },
+        },
+      },
     })
   })
 
@@ -206,17 +261,17 @@ describe("with TS Syntax", () => {
     const controller = parseController(code, "value_controller.js")
 
     expect(controller.valueDefinitionsMap).toEqual({
-      object: { 
-        type: "Object", 
-        default: { object: { some: { more: { levels: {} } } } }, 
+      object: {
+        type: "Object",
+        default: { object: { some: { more: { levels: {} } } } },
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
-        keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } } 
+        keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
-      array: { 
-        type: "Array", 
-        default: [["Array", "with", ["nested", ["values"]]]], 
+      array: {
+        type: "Array",
+        default: [["Array", "with", ["nested", ["values"]]]],
         valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } },
-        keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } } 
+        keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } }
       },
     })
   })

--- a/test/parser/typescript.test.ts
+++ b/test/parser/typescript.test.ts
@@ -170,34 +170,34 @@ describe("with TS Syntax", () => {
       string: {
         type: "String",
         default: "string",
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       object: {
         type: "Object",
         default: { object: "Object" },
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 26, line: 6 }, start: { column: 20, line: 6 } },
         keyLoc: { end: { column: 18, line: 6 }, start: { column: 14, line: 6 } } },
       boolean: {
         type: "Boolean",
         default: true,
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 28, line: 7 }, start: { column: 21, line: 7 } },
         keyLoc: { end: { column: 19, line: 7 }, start: { column: 15, line: 7 } }
       },
       array: {
         type: "Array",
         default: ["Array"],
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 24, line: 8 }, start: { column: 19, line: 8 } },
         keyLoc: { end: { column: 17, line: 8 }, start: { column: 13, line: 8 } }
       },
       number: {
         type: "Number",
         default: 1,
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 26, line: 9 }, start: { column: 20, line: 9 } },
         keyLoc: { end: { column: 18, line: 9 }, start: { column: 14, line: 9 } }
       },
@@ -298,14 +298,14 @@ describe("with TS Syntax", () => {
       object: {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } },
         keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } }
       },

--- a/test/parser/values.test.ts
+++ b/test/parser/values.test.ts
@@ -287,7 +287,7 @@ describe("parse values", () => {
         @Value(String) stringValue! = "string"
         @Value(Object) objectValue! = {}
         @Value(Boolean) booleanValue! = false
-        @Value(Array) arrayValue! = []
+        @Value(Array) arrayValue! = [1, 2, 3]
         @Value(Number) numberValue! = 10
       }
     `
@@ -299,8 +299,11 @@ describe("parse values", () => {
       string: { type: "String", default: "string" },
       object: { type: "Object", default: {} },
       boolean: { type: "Boolean", default: false },
-      array: { type: "Array", default: [] },
       number: { type: "Number", default: 10 },
+      array: {
+        type: "Array",
+        default: [1, 2, 3],
+      },
     })
   })
 

--- a/test/parser/values.test.ts
+++ b/test/parser/values.test.ts
@@ -22,11 +22,66 @@ describe("parse values", () => {
 
     expect(controller.isTyped).toBeFalsy()
     expect(controller.valueDefinitionsMap).toEqual({
-      string: { type: "String", default: "" },
-      object: { type: "Object", default: {} },
-      boolean: { type: "Boolean", default: false },
-      array: { type: "Array", default: [] },
-      number: { type: "Number", default: 0 },
+      array: {
+        type: "Array",
+        default: [],
+        keyLoc: {
+          end: { column: 9, line: 8 },
+          start: { column: 4, line: 8 },
+        },
+        valueLoc: {
+          end: { column: 16, line: 8 },
+          start: { column: 11, line: 8 },
+        },
+      },
+      boolean: {
+        type: "Boolean",
+        default: false,
+        keyLoc: {
+          end: { column: 11, line: 7 },
+          start: { column: 4, line: 7 },
+        },
+        valueLoc: {
+          end: { column: 20, line: 7 },
+          start: { column: 13, line: 7 },
+        },
+      },
+      number: {
+        type: "Number",
+        default: 0,
+        keyLoc: {
+          end: { column: 10, line: 9 },
+          start: { column: 4, line: 9 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 9 },
+          start: { column: 12, line: 9 },
+        },
+      },
+      object: {
+        type: "Object",
+        default: {},
+        keyLoc: {
+          end: { column: 10, line: 6 },
+          start: { column: 4, line: 6 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 6 },
+          start: { column: 12, line: 6 },
+        },
+      },
+      string: {
+        type: "String",
+        default: "",
+        keyLoc: {
+          end: { column: 10, line: 5 },
+          start: { column: 4, line: 5 },
+        },
+        valueLoc: {
+          end: { column: 18, line: 5 },
+          start: { column: 12, line: 5 },
+        },
+      },
     })
   })
 
@@ -230,7 +285,7 @@ describe("parse values", () => {
       @TypedController
       export default class extends Controller {
         static values = {
-          one: { type: "String", default: ""}
+          one: { type: "String", default: "" }
         }
 
         @Value(String) oneValue!: string;
@@ -269,11 +324,36 @@ describe("parse values", () => {
 
     expect(controller.isTyped).toBeTruthy()
     expect(controller.valueDefinitionsMap).toEqual({
-      string: { type: "String", default: "" },
-      object: { type: "Object", default: {} },
-      boolean: { type: "Boolean", default: false },
-      array: { type: "Array", default: [] },
-      number: { type: "Number", default: 0 },
+      array: {
+        type: "Array",
+        default: [],
+        keyLoc: { end: { column: 15, line: 9 }, start: { column: 2, line: 9 } },
+        valueLoc: { end: { column: 32, line: 9 }, start: { column: 2, line: 9 } },
+      },
+      boolean: {
+        type: "Boolean",
+        default: false,
+        keyLoc: { end: { column: 17, line: 8 }, start: { column: 2, line: 8 } },
+        valueLoc: { end: { column: 41, line: 8 }, start: { column: 2, line: 8 } },
+      },
+      number: {
+        type: "Number",
+        default: 0,
+        keyLoc: { end: { column: 16, line: 10 }, start: { column: 2, line: 10 } },
+        valueLoc: { end: { column: 38, line: 10 }, start: { column: 2, line: 10 } },
+      },
+      object: {
+        type: "Object",
+        default: {},
+        keyLoc: { end: { column: 16, line: 7 }, start: { column: 2, line: 7 } },
+        valueLoc: { end: { column: 34, line: 7 }, start: { column: 2, line: 7 } },
+      },
+      string: {
+        type: "String",
+        default: "",
+        keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
+        valueLoc: { end: { column: 38, line: 6 }, start: { column: 2, line: 6 } },
+      },
     })
   })
 
@@ -285,8 +365,8 @@ describe("parse values", () => {
       @TypedController
       export default class extends Controller {
         @Value(String) stringValue! = "string"
-        @Value(Object) objectValue! = {}
-        @Value(Boolean) booleanValue! = false
+        @Value(Object) objectValue! = { hello: "world" }
+        @Value(Boolean) booleanValue! = true
         @Value(Array) arrayValue! = [1, 2, 3]
         @Value(Number) numberValue! = 10
       }
@@ -296,13 +376,35 @@ describe("parse values", () => {
 
     expect(controller.isTyped).toBeTruthy()
     expect(controller.valueDefinitionsMap).toEqual({
-      string: { type: "String", default: "string" },
-      object: { type: "Object", default: {} },
-      boolean: { type: "Boolean", default: false },
-      number: { type: "Number", default: 10 },
       array: {
         type: "Array",
         default: [1, 2, 3],
+        keyLoc: { end: { column: 15, line: 9 }, start: { column: 2, line: 9 } },
+        valueLoc: { end: { column: 39, line: 9 }, start: { column: 2, line: 9 } },
+      },
+      boolean: {
+        type: "Boolean",
+        default: true,
+        keyLoc: { end: { column: 17, line: 8 }, start: { column: 2, line: 8 } },
+        valueLoc: { end: { column: 38, line: 8 }, start: { column: 2, line: 8 } },
+      },
+      number: {
+        type: "Number",
+        default: 10,
+        keyLoc: { end: { column: 16, line: 10 }, start: { column: 2, line: 10 } },
+        valueLoc: { end: { column: 34, line: 10 }, start: { column: 2, line: 10 } },
+      },
+      object: {
+        type: "Object",
+        default: { hello: "world" },
+        keyLoc: { end: { column: 16, line: 7 }, start: { column: 2, line: 7 } },
+        valueLoc: { end: { column: 50, line: 7 }, start: { column: 2, line: 7 } },
+      },
+      string: {
+        type: "String",
+        default: "string",
+        keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
+        valueLoc: { end: { column: 40, line: 6 }, start: { column: 2, line: 6 } },
       },
     })
   })
@@ -354,13 +456,17 @@ describe("parse values", () => {
 
     expect(controller.isTyped).toBeTruthy()
     expect(controller.valueDefinitionsMap).toEqual({
-      object: {
-        type: "Object",
-        default: { object: { some: { more: { levels: {} } } } },
-      },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
+        keyLoc: { end: { column: 15, line: 7 }, start: { column: 2, line: 7 } },
+        valueLoc: { end: { column: 73, line: 7 }, start: { column: 2, line: 7 } },
+      },
+      object: {
+        type: "Object",
+        default: { object: { some: { more: { levels: {} } } } },
+        keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
+        valueLoc: { end: { column: 78, line: 6 }, start: { column: 2, line: 6 } },
       },
     })
   })

--- a/test/parser/values.test.ts
+++ b/test/parser/values.test.ts
@@ -470,4 +470,76 @@ describe("parse values", () => {
       },
     })
   })
+
+  test("implicit version", () => {
+    const code = dedent`
+      import { Controller } from "@hotwired/stimulus";
+
+      export default class extends Controller {
+        static values = {
+          string: "Number"
+        }
+      }
+    `
+
+    const controller = parseController(code, "value_controller.ts")
+
+    expect(controller.isTyped).toBeFalsy()
+    expect(controller.valueDefinitionsMap).toEqual({
+      string: {
+        type: "String",
+        default: "Number",
+        kind: "inferred",
+      },
+    })
+  })
+
+  test("shorthand-version", () => {
+    const code = dedent`
+      import { Controller } from "@hotwired/stimulus";
+
+      export default class extends Controller {
+        static values = {
+          name: String,
+        }
+      }
+    `
+
+    const controller = parseController(code, "value_controller.ts")
+
+    expect(controller.isTyped).toBeFalsy()
+    expect(controller.valueDefinitionsMap).toEqual({
+      name: {
+        type: "String",
+        default: "Number",
+        kind: "short",
+      },
+    })
+  })
+
+  test("explicit-version", () => {
+    const code = dedent`
+      import { Controller } from "@hotwired/stimulus";
+
+      export default class extends Controller {
+        static values = {
+          name: {
+            type: String,
+            default: "Stimulus"
+          }
+        }
+      }
+    `
+
+    const controller = parseController(code, "value_controller.ts")
+
+    expect(controller.isTyped).toBeFalsy()
+    expect(controller.valueDefinitionsMap).toEqual({
+      name: {
+        type: "String",
+        default: "Number",
+        kind: "explicit",
+      },
+    })
+  })
 })

--- a/test/parser/values.test.ts
+++ b/test/parser/values.test.ts
@@ -25,6 +25,7 @@ describe("parse values", () => {
       array: {
         type: "Array",
         default: [],
+        kind: "shorthand",
         keyLoc: {
           end: { column: 9, line: 8 },
           start: { column: 4, line: 8 },
@@ -37,6 +38,7 @@ describe("parse values", () => {
       boolean: {
         type: "Boolean",
         default: false,
+        kind: "shorthand",
         keyLoc: {
           end: { column: 11, line: 7 },
           start: { column: 4, line: 7 },
@@ -49,6 +51,7 @@ describe("parse values", () => {
       number: {
         type: "Number",
         default: 0,
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 9 },
           start: { column: 4, line: 9 },
@@ -61,6 +64,7 @@ describe("parse values", () => {
       object: {
         type: "Object",
         default: {},
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 6 },
           start: { column: 4, line: 6 },
@@ -73,6 +77,7 @@ describe("parse values", () => {
       string: {
         type: "String",
         default: "",
+        kind: "shorthand",
         keyLoc: {
           end: { column: 10, line: 5 },
           start: { column: 4, line: 5 },
@@ -107,6 +112,7 @@ describe("parse values", () => {
       string: {
         type: "String",
         default: "string",
+        kind: "explicit",
         valueLoc: {
           end: { column: 26, line: 5 },
           start: { column: 20, line: 5 },
@@ -119,6 +125,7 @@ describe("parse values", () => {
       object: {
         type: "Object",
         default: { object: "Object" },
+        kind: "explicit",
         valueLoc: {
           end: { column: 26, line: 6 },
           start: { column: 20, line: 6 },
@@ -131,6 +138,7 @@ describe("parse values", () => {
       boolean: {
         type: "Boolean",
         default: true,
+        kind: "explicit",
         valueLoc: {
           end: { column: 28, line: 7 },
           start: { column: 21, line: 7 },
@@ -143,6 +151,7 @@ describe("parse values", () => {
       array: {
         type: "Array",
         default: ["Array"],
+        kind: "explicit",
         valueLoc: {
           end: { column: 24, line: 8 },
           start: { column: 19, line: 8 },
@@ -155,6 +164,7 @@ describe("parse values", () => {
       number: {
         type: "Number",
         default: 1,
+        kind: "explicit",
         valueLoc: {
           end: { column: 26, line: 9 },
           start: { column: 20, line: 9 },
@@ -327,30 +337,35 @@ describe("parse values", () => {
       array: {
         type: "Array",
         default: [],
+        kind: "decorator",
         keyLoc: { end: { column: 15, line: 9 }, start: { column: 2, line: 9 } },
         valueLoc: { end: { column: 32, line: 9 }, start: { column: 2, line: 9 } },
       },
       boolean: {
         type: "Boolean",
         default: false,
+        kind: "decorator",
         keyLoc: { end: { column: 17, line: 8 }, start: { column: 2, line: 8 } },
         valueLoc: { end: { column: 41, line: 8 }, start: { column: 2, line: 8 } },
       },
       number: {
         type: "Number",
         default: 0,
+        kind: "decorator",
         keyLoc: { end: { column: 16, line: 10 }, start: { column: 2, line: 10 } },
         valueLoc: { end: { column: 38, line: 10 }, start: { column: 2, line: 10 } },
       },
       object: {
         type: "Object",
         default: {},
+        kind: "decorator",
         keyLoc: { end: { column: 16, line: 7 }, start: { column: 2, line: 7 } },
         valueLoc: { end: { column: 34, line: 7 }, start: { column: 2, line: 7 } },
       },
       string: {
         type: "String",
         default: "",
+        kind: "decorator",
         keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
         valueLoc: { end: { column: 38, line: 6 }, start: { column: 2, line: 6 } },
       },
@@ -379,30 +394,35 @@ describe("parse values", () => {
       array: {
         type: "Array",
         default: [1, 2, 3],
+        kind: "decorator",
         keyLoc: { end: { column: 15, line: 9 }, start: { column: 2, line: 9 } },
         valueLoc: { end: { column: 39, line: 9 }, start: { column: 2, line: 9 } },
       },
       boolean: {
         type: "Boolean",
         default: true,
+        kind: "decorator",
         keyLoc: { end: { column: 17, line: 8 }, start: { column: 2, line: 8 } },
         valueLoc: { end: { column: 38, line: 8 }, start: { column: 2, line: 8 } },
       },
       number: {
         type: "Number",
         default: 10,
+        kind: "decorator",
         keyLoc: { end: { column: 16, line: 10 }, start: { column: 2, line: 10 } },
         valueLoc: { end: { column: 34, line: 10 }, start: { column: 2, line: 10 } },
       },
       object: {
         type: "Object",
         default: { hello: "world" },
+        kind: "decorator",
         keyLoc: { end: { column: 16, line: 7 }, start: { column: 2, line: 7 } },
         valueLoc: { end: { column: 50, line: 7 }, start: { column: 2, line: 7 } },
       },
       string: {
         type: "String",
         default: "string",
+        kind: "decorator",
         keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
         valueLoc: { end: { column: 40, line: 6 }, start: { column: 2, line: 6 } },
       },
@@ -428,12 +448,14 @@ describe("parse values", () => {
       object: {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
+        kind: "explicit",
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } },
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
+        kind: "explicit",
         keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } },
         valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } }
       },
@@ -459,19 +481,21 @@ describe("parse values", () => {
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
+        kind: "decorator",
         keyLoc: { end: { column: 15, line: 7 }, start: { column: 2, line: 7 } },
         valueLoc: { end: { column: 73, line: 7 }, start: { column: 2, line: 7 } },
       },
       object: {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
+        kind: "decorator",
         keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
         valueLoc: { end: { column: 78, line: 6 }, start: { column: 2, line: 6 } },
       },
     })
   })
 
-  test("implicit version", () => {
+  test.todo("implicit version", () => {
     const code = dedent`
       import { Controller } from "@hotwired/stimulus";
 
@@ -490,6 +514,8 @@ describe("parse values", () => {
         type: "String",
         default: "Number",
         kind: "inferred",
+        keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
+        valueLoc: { end: { column: 78, line: 6 }, start: { column: 2, line: 6 } },
       },
     })
   })
@@ -511,8 +537,10 @@ describe("parse values", () => {
     expect(controller.valueDefinitionsMap).toEqual({
       name: {
         type: "String",
-        default: "Number",
-        kind: "short",
+        default: "",
+        kind: "shorthand",
+        keyLoc: { end: { column: 8, line: 5 }, start: { column: 4, line: 5 } },
+        valueLoc: { end: { column: 16, line: 5 }, start: { column: 10, line: 5 } },
       },
     })
   })
@@ -537,8 +565,10 @@ describe("parse values", () => {
     expect(controller.valueDefinitionsMap).toEqual({
       name: {
         type: "String",
-        default: "Number",
+        default: "Stimulus",
         kind: "explicit",
+        keyLoc: { end: { column: 10, line: 6 }, start: { column: 6, line: 6 } },
+        valueLoc: { end: { column: 18, line: 6 }, start: { column: 12, line: 6 } },
       },
     })
   })

--- a/test/parser/values.test.ts
+++ b/test/parser/values.test.ts
@@ -112,7 +112,7 @@ describe("parse values", () => {
       string: {
         type: "String",
         default: "string",
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: {
           end: { column: 26, line: 5 },
           start: { column: 20, line: 5 },
@@ -125,7 +125,7 @@ describe("parse values", () => {
       object: {
         type: "Object",
         default: { object: "Object" },
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: {
           end: { column: 26, line: 6 },
           start: { column: 20, line: 6 },
@@ -138,7 +138,7 @@ describe("parse values", () => {
       boolean: {
         type: "Boolean",
         default: true,
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: {
           end: { column: 28, line: 7 },
           start: { column: 21, line: 7 },
@@ -151,7 +151,7 @@ describe("parse values", () => {
       array: {
         type: "Array",
         default: ["Array"],
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: {
           end: { column: 24, line: 8 },
           start: { column: 19, line: 8 },
@@ -164,7 +164,7 @@ describe("parse values", () => {
       number: {
         type: "Number",
         default: 1,
-        kind: "explicit",
+        kind: "expanded",
         valueLoc: {
           end: { column: 26, line: 9 },
           start: { column: 20, line: 9 },
@@ -448,14 +448,14 @@ describe("parse values", () => {
       object: {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
-        kind: "explicit",
+        kind: "expanded",
         keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } },
         valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
-        kind: "explicit",
+        kind: "expanded",
         keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } },
         valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } }
       },
@@ -545,7 +545,7 @@ describe("parse values", () => {
     })
   })
 
-  test("explicit-version", () => {
+  test("expanded-version", () => {
     const code = dedent`
       import { Controller } from "@hotwired/stimulus";
 
@@ -566,7 +566,7 @@ describe("parse values", () => {
       name: {
         type: "String",
         default: "Stimulus",
-        kind: "explicit",
+        kind: "expanded",
         keyLoc: { end: { column: 10, line: 6 }, start: { column: 6, line: 6 } },
         valueLoc: { end: { column: 18, line: 6 }, start: { column: 12, line: 6 } },
       },


### PR DESCRIPTION
This pull request implements the `kind` for `ValueDefinition`'s.

It only implements the `"shorthand"`, `"expanded"`, and `"decorator"` kinds, since those are the ones we currently support already. I opened #107 to account for the `"inferred"` kind.

Resolves https://github.com/marcoroth/stimulus-parser/issues/79