### PR TITLE
Add `loc` getters to Value Definition

### DIFF
--- a/src/class_declaration.ts
+++ b/src/class_declaration.ts
@@ -144,7 +144,7 @@ export class ClassDeclaration {
         const isPrivate = node.key.type === "PrivateIdentifier" || tsNode.accessibility === "private"
         const name = isPrivate ? `#${methodName}` : methodName
 
-        this.controllerDefinition.methodDefinitions.push(new MethodDefinition(name, node, node.loc, "static"))
+        this.controllerDefinition.methodDefinitions.push(new MethodDefinition(name, node, node, node.loc, "static"))
       },
 
       PropertyDefinition: node => {
@@ -152,7 +152,7 @@ export class ClassDeclaration {
         if (node.key.type !== "Identifier") return
         if (!node.value || node.value.type !== "ArrowFunctionExpression") return
 
-        this.controllerDefinition.methodDefinitions.push(new MethodDefinition(node.key.name, node, node.loc, "static"))
+        this.controllerDefinition.methodDefinitions.push(new MethodDefinition(node.key.name, node, node, node.loc, "static"))
       },
     })
   }

--- a/src/controller_definition.ts
+++ b/src/controller_definition.ts
@@ -223,9 +223,9 @@ export class ControllerDefinition {
 
   addTargetDefinition(targetDefinition: TargetDefinition): void {
     if (this.localTargetNames.includes(targetDefinition.name)) {
-      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Target "${targetDefinition.name}"`, targetDefinition.loc))
+      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Target "${targetDefinition.name}"`, targetDefinition.elementNode.loc))
     } else if (this.targetNames.includes(targetDefinition.name)) {
-      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Target "${targetDefinition.name}". A parent controller already defines this Target.`, targetDefinition.loc))
+      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Target "${targetDefinition.name}". A parent controller already defines this Target.`, targetDefinition.elementNode.loc))
     }
 
     this.targetDefinitions.push(targetDefinition)
@@ -233,9 +233,9 @@ export class ControllerDefinition {
 
   addClassDefinition(classDefinition: ClassDefinition) {
     if (this.localClassNames.includes(classDefinition.name)) {
-      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Class "${classDefinition.name}"`, classDefinition.loc))
+      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Class "${classDefinition.name}"`, classDefinition.elementNode.loc))
     } else if (this.classNames.includes(classDefinition.name)) {
-      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Class "${classDefinition.name}". A parent controller already defines this Class.`, classDefinition.loc))
+      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Class "${classDefinition.name}". A parent controller already defines this Class.`, classDefinition.elementNode.loc))
     }
 
     this.classDefinitions.push(classDefinition)

--- a/src/controller_definition.ts
+++ b/src/controller_definition.ts
@@ -243,9 +243,9 @@ export class ControllerDefinition {
 
   addValueDefinition(valueDefinition: ValueDefinition) {
     if (this.localValueNames.includes(valueDefinition.name)) {
-      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Value "${valueDefinition.name}"`, valueDefinition.definition.keyLoc))
+      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Value "${valueDefinition.name}"`, valueDefinition.keyLoc))
     } else if (this.valueNames.includes(valueDefinition.name)) {
-      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Value "${valueDefinition.name}". A parent controller already defines this Value.`, valueDefinition.definition.keyLoc))
+      this.errors.push(new ParseError("LINT", `Duplicate definition of Stimulus Value "${valueDefinition.name}". A parent controller already defines this Value.`, valueDefinition.keyLoc))
     }
 
     this.valueDefinitions.push(valueDefinition)

--- a/src/controller_definition.ts
+++ b/src/controller_definition.ts
@@ -128,11 +128,11 @@ export class ControllerDefinition {
   }
 
   get valueDefinitionsMap() {
-    return Object.fromEntries(this.values.map(definition => [definition.name, definition.definition]))
+    return Object.fromEntries(this.values.map(definition => [definition.name, definition]))
   }
 
   get localValueDefinitionsMap() {
-    return Object.fromEntries(this.localValues.map(definition => [definition.name, definition.definition]))
+    return Object.fromEntries(this.localValues.map(definition => [definition.name, definition]))
   }
 
   get controllerRoot(): string {

--- a/src/controller_property_definition.ts
+++ b/src/controller_property_definition.ts
@@ -38,7 +38,7 @@ export class ValueDefinition extends ControllerPropertyDefinition {
       return
     }
     const node = this.node as Acorn.ObjectExpression
-    return findPropertyInProperties(node.properties, this.name)
+    return findPropertyInProperties(node.properties, this.name, this.node.type)
   }
 
   get keyLoc() {

--- a/src/controller_property_definition.ts
+++ b/src/controller_property_definition.ts
@@ -46,11 +46,12 @@ export class ValueDefinition extends ControllerPropertyDefinition {
     if(!this.propertyValues) {
       return 
     }
-    switch(this.propertyValues.value.type) {
-      case "Identifier": 
+    switch(this.definition.kind) {
+      case "shorthand": 
         return this.propertyValues.value.loc
-      case "ObjectExpression": 
-        const valueLocation = findPropertyInProperties(this.propertyValues.value.properties, "type")?.value?.loc
+      case "expanded": 
+        const propValues = this.propertyValues.value as Acorn.ObjectExpression
+        const valueLocation = findPropertyInProperties(propValues.properties, "type")?.value?.loc
         return valueLocation
         default: 
           return

--- a/src/controller_property_definition.ts
+++ b/src/controller_property_definition.ts
@@ -44,7 +44,7 @@ export class ValueDefinition extends ControllerPropertyDefinition {
 
   get keyLoc() {
     if (this.definitionType === "decorator") {
-      return (this.node as Acorn.PropertyDefinition).key.loc
+      return (this.node as Acorn.PropertyDefinition).key?.loc || this.node.loc
     }
 
     return this.propertyValues?.key.loc || this.node.loc
@@ -53,14 +53,15 @@ export class ValueDefinition extends ControllerPropertyDefinition {
   get typeLoc() {
     switch(this.definition.kind) {
       case "shorthand":
-        return this.propertyValues?.value.loc
+        return this.propertyValues?.value.loc || this.node.loc
 
       case "expanded":
         const propValues = this.propertyValues?.value as Acorn.ObjectExpression
-        return findPropertyInProperties(propValues.properties, "type")?.value?.loc
+        return findPropertyInProperties(propValues.properties, "type")?.value?.loc || this.node.loc
 
       case "decorator":
-        return (this.node as any as TSESTree.PropertyDefinition).decorators[0]?.loc || this.node.loc
+        const decorators = (this.node as any as TSESTree.PropertyDefinition).decorators || []
+        return decorators[0]?.loc || this.node.loc
 
       default:
         return this.node.loc

--- a/src/controller_property_definition.ts
+++ b/src/controller_property_definition.ts
@@ -32,6 +32,28 @@ export class ValueDefinition extends ControllerPropertyDefinition {
     return this.definition.type
   }
 
+  get propertyValues() {
+    const node = this.node as Acorn.ObjectExpression
+    const properties = node.properties.filter(property => property.type === "Property") as Acorn.Property[]
+    return properties.find(property =>
+      ((property.key.type === "Identifier") ? property.key.name : undefined) === this.name
+    )
+  }
+
+  get keyLocTest() {
+    if(!this.propertyValues) {
+      return 
+    }
+    return this.propertyValues.key.loc
+  }
+
+  get valueLocTest() {
+    if(!this.propertyValues) {
+      return 
+    }
+    return this.propertyValues.value.loc
+  }
+
   get default() {
     return this.definition.default
   }

--- a/src/controller_property_definition.ts
+++ b/src/controller_property_definition.ts
@@ -38,13 +38,6 @@ export class ValueDefinition extends ControllerPropertyDefinition {
     return this.definition.type
   }
 
-  get propertyValues() {
-    if (this.definitionType === "decorator") return
-
-    const node = this.node as Acorn.ObjectExpression
-    return findPropertyInProperties(node.properties, this.name)
-  }
-
   get keyLoc() {
     if (this.definitionType === "decorator") {
       return (this.node as Acorn.PropertyDefinition).key?.loc || this.node.loc
@@ -79,7 +72,7 @@ export class ValueDefinition extends ControllerPropertyDefinition {
       return (this.node as Acorn.PropertyDefinition).value?.loc || this.node.loc
     }
 
-    return this.propertyValues?.value.loc || this.node.loc
+    return (this.elementNode as Acorn.PropertyDefinition).value?.loc || this.node.loc
   }
 
   get default() {

--- a/src/controller_property_definition.ts
+++ b/src/controller_property_definition.ts
@@ -34,15 +34,18 @@ export class ValueDefinition extends ControllerPropertyDefinition {
   }
 
   get propertyValues() {
+    if(this.definitionType === "decorator") {
+      return
+    }
     const node = this.node as Acorn.ObjectExpression
     return findPropertyInProperties(node.properties, this.name)
   }
 
-  get keyLocTest() {
+  get keyLoc() {
     return this.propertyValues?.key.loc
   }
 
-  get typeLocTest() {
+  get typeLoc() {
     if(!this.propertyValues) {
       return 
     }
@@ -58,7 +61,7 @@ export class ValueDefinition extends ControllerPropertyDefinition {
     }
   }
 
-  get valueLocTest() {
+  get valueLoc() {
     return this.propertyValues?.value.loc
   }
 

--- a/src/controller_property_definition.ts
+++ b/src/controller_property_definition.ts
@@ -27,7 +27,7 @@ export class ValueDefinition extends ControllerPropertyDefinition {
     name: string,
     public readonly definition: ValueDefinitionType,
     node: Node,
-    propertyNode: Acorn.Property,
+    private propertyNode: Acorn.Property,
     loc?: Acorn.SourceLocation | null,
     definitionType: "decorator" | "static" = "static",
   ) {
@@ -43,20 +43,21 @@ export class ValueDefinition extends ControllerPropertyDefinition {
       return (this.node as Acorn.PropertyDefinition).key?.loc || this.node.loc
     }
 
-    return (this.elementNode as Acorn.PropertyDefinition).key?.loc || this.node.loc
+    return this.propertyNode.key?.loc || this.node.loc
   }
 
   get typeLoc() {
     switch(this.definition.kind) {
       case "shorthand":
-        return (this.elementNode as Acorn.PropertyDefinition).value?.loc || this.node.loc
+        return this.propertyNode.value?.loc || this.node.loc
 
       case "expanded":
-        const propValues = (this.elementNode as Acorn.Property)?.value as Acorn.ObjectExpression | undefined
+        const propertyValue = this.propertyNode?.value
 
-        if (!propValues) return this.node.loc
+        if (!propertyValue) return this.node.loc
+        if (propertyValue.type !== "ObjectExpression") return
 
-        return findPropertyInProperties(propValues.properties, "type")?.value?.loc || this.node.loc
+        return findPropertyInProperties(propertyValue.properties, "type")?.value?.loc || this.node.loc
 
       case "decorator":
         const decorators = (this.node as any as TSESTree.PropertyDefinition).decorators || []
@@ -72,7 +73,7 @@ export class ValueDefinition extends ControllerPropertyDefinition {
       return (this.node as Acorn.PropertyDefinition).value?.loc || this.node.loc
     }
 
-    return (this.elementNode as Acorn.PropertyDefinition).value?.loc || this.node.loc
+    return this.propertyNode.value?.loc || this.node.loc
   }
 
   get default() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -12,8 +12,6 @@ export type ValueDefinitionKind = "expanded" | "inferred" | "shorthand" | "decor
 export type ValueDefinition = {
   type: string
   default: ValueDefinitionValue
-  keyLoc: Acorn.SourceLocation | undefined | null
-  valueLoc: Acorn.SourceLocation | undefined | null
   kind: ValueDefinitionKind
 }
 

--- a/src/util/ast.ts
+++ b/src/util/ast.ts
@@ -3,18 +3,13 @@ import { ValueDefinition } from "../controller_property_definition"
 import type * as Acorn from "acorn"
 import type { NestedObject, ValueDefinitionValue, ValueDefinition as ValueDefinitionType } from "../types"
 
-export function findPropertyInProperties(_properties: (Acorn.Property | Acorn.SpreadElement)[], propertyName: string, valueKind?: (string | null | undefined)): Acorn.Property | undefined {
+export function findPropertyInProperties(_properties: (Acorn.Property | Acorn.SpreadElement)[], propertyName: string): Acorn.Property | undefined {
+
   const properties = _properties.filter(property => property.type === "Property") as Acorn.Property[]
 
-  const foundProperties = properties.filter(property =>
+  return properties.find(property =>
     ((property.key.type === "Identifier") ? property.key.name : undefined) === propertyName
   )
-
-  if(valueKind) {
-    return foundProperties.find(property => property.value.type === valueKind)
-  } else {
-    return foundProperties[0]
-  }
 }
 
 export function convertArrayExpressionToLiterals(value: Acorn.ArrayExpression): Array<ValueDefinitionValue> {

--- a/src/util/decorators.ts
+++ b/src/util/decorators.ts
@@ -48,7 +48,7 @@ export function parseDecorator(controllerDefinition: ControllerDefinition | unde
 export function parseTargetDecorator(controllerDefinition: ControllerDefinition, name: string, node: TSESTree.PropertyDefinition): void {
   controllerDefinition.anyDecorator = true
 
-  const targetDefinition = new TargetDefinition(stripDecoratorSuffix(name, "Target"), node as any, node.loc, "decorator")
+  const targetDefinition = new TargetDefinition(stripDecoratorSuffix(name, "Target"), node as any, node as any, node.loc, "decorator")
 
   controllerDefinition.addTargetDefinition(targetDefinition)
 }
@@ -56,7 +56,7 @@ export function parseTargetDecorator(controllerDefinition: ControllerDefinition,
 export function parseClassDecorator(controllerDefinition: ControllerDefinition, name: string, node: TSESTree.PropertyDefinition): void {
   controllerDefinition.anyDecorator = true
 
-  const classDefinition = new ClassDefinition(stripDecoratorSuffix(name, "Class"), node as any, node.loc, "decorator")
+  const classDefinition = new ClassDefinition(stripDecoratorSuffix(name, "Class"), node as any, node as any, node.loc, "decorator")
 
   controllerDefinition.addClassDefinition(classDefinition)
 }
@@ -89,7 +89,7 @@ export function parseValueDecorator(controllerDefinition: ControllerDefinition, 
     kind: "decorator"
   }
 
-  const valueDefinition = new ValueDefinition(key, definition, node as any, node.loc, "decorator")
+  const valueDefinition = new ValueDefinition(key, definition, node as any, node as any, node.loc, "decorator")
 
   controllerDefinition.addValueDefinition(valueDefinition)
 }

--- a/src/util/decorators.ts
+++ b/src/util/decorators.ts
@@ -86,9 +86,7 @@ export function parseValueDecorator(controllerDefinition: ControllerDefinition, 
   const definition: ValueDefinitionType = {
     type: type.name,
     default: defaultValue,
-    kind: "decorator",
-    keyLoc: decorator.loc,
-    valueLoc: node.loc
+    kind: "decorator"
   }
 
   const valueDefinition = new ValueDefinition(key, definition, node as any, node.loc, "decorator")

--- a/src/util/properties.ts
+++ b/src/util/properties.ts
@@ -9,17 +9,17 @@ export function parseStaticControllerProperties(controllerDefinition: Controller
 
   if (right.type === "ArrayExpression") {
     if (left.name === "targets") {
-      ast.convertArrayExpressionToStrings(right).map(element =>
+      ast.convertArrayExpressionToStringsAndNodes(right).map(([element, elementNode]) =>
         controllerDefinition.addTargetDefinition(
-          new TargetDefinition(element, right, right.loc, "static")
+          new TargetDefinition(element, right, elementNode, right.loc, "static")
         )
       )
     }
 
     if (left.name === "classes") {
-      ast.convertArrayExpressionToStrings(right).map(element =>
+      ast.convertArrayExpressionToStringsAndNodes(right).map(([element, elementNode]) =>
         controllerDefinition.addClassDefinition(
-          new ClassDefinition(element, right, right.loc, "static")
+          new ClassDefinition(element, right, elementNode, right.loc, "static")
         )
       )
     }
@@ -28,9 +28,9 @@ export function parseStaticControllerProperties(controllerDefinition: Controller
   if (right.type === "ObjectExpression" && left.name === "values") {
     const definitions = ast.convertObjectExpressionToValueDefinitions(right)
 
-    definitions.forEach(([name, valueDefinition]) => {
+    definitions.forEach(([name, valueDefinition, propertyNode]) => {
       controllerDefinition.addValueDefinition(
-        new ValueDefinition(name, valueDefinition, right, right.loc, "static")
+        new ValueDefinition(name, valueDefinition, right, propertyNode, right.loc, "static")
       )
     })
   }

--- a/test/helpers/matchers.ts
+++ b/test/helpers/matchers.ts
@@ -1,0 +1,3 @@
+import type { SourceLocation } from "acorn"
+
+export const extractLoc = (loc: SourceLocation) => [loc?.start?.line, loc?.start?.column, loc?.end?.line, loc?.end?.column]

--- a/test/parser/classes.test.ts
+++ b/test/parser/classes.test.ts
@@ -35,9 +35,9 @@ describe("parse classes", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Class "one"`)
     expect(controller.errors[0].loc.start.line).toEqual(4)
-    expect(controller.errors[0].loc.start.column).toEqual(19)
+    expect(controller.errors[0].loc.start.column).toEqual(27)
     expect(controller.errors[0].loc.end.line).toEqual(4)
-    expect(controller.errors[0].loc.end.column).toEqual(42)
+    expect(controller.errors[0].loc.end.column).toEqual(32)
   })
 
   test("duplicate static classes from parent", () => {
@@ -61,9 +61,9 @@ describe("parse classes", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Class "one". A parent controller already defines this Class.`)
     expect(controller.errors[0].loc.start.line).toEqual(8)
-    expect(controller.errors[0].loc.start.column).toEqual(19)
+    expect(controller.errors[0].loc.start.column).toEqual(20)
     expect(controller.errors[0].loc.end.line).toEqual(8)
-    expect(controller.errors[0].loc.end.column).toEqual(35)
+    expect(controller.errors[0].loc.end.column).toEqual(25)
   })
 
   test("assigns classes outside of class via member expression", () => {

--- a/test/parser/javascript.test.ts
+++ b/test/parser/javascript.test.ts
@@ -81,66 +81,26 @@ describe("with JS Syntax", () => {
         type: "Array",
         default: [],
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 9, line: 8 },
-          start: { column: 4, line: 8 },
-        },
-        valueLoc: {
-          end: { column: 16, line: 8 },
-          start: { column: 11, line: 8 },
-        },
       },
       boolean: {
         type: "Boolean",
         default: false,
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 11, line: 7 },
-          start: { column: 4, line: 7 },
-        },
-        valueLoc: {
-          end: { column: 20, line: 7 },
-          start: { column: 13, line: 7 },
-        },
       },
       number: {
         type: "Number",
         default: 0,
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 9 },
-          start: { column: 4, line: 9 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 9 },
-          start: { column: 12, line: 9 },
-        },
       },
       object: {
         type: "Object",
         default: {},
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 6 },
-          start: { column: 4, line: 6 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 6 },
-          start: { column: 12, line: 6 },
-        },
       },
       string: {
         type: "String",
         default: "",
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 5 },
-          start: { column: 4, line: 5 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 5 },
-          start: { column: 12, line: 5 },
-        },
       },
     })
   })
@@ -166,36 +126,26 @@ describe("with JS Syntax", () => {
         type: "String",
         default: "string",
         kind: "expanded",
-        valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
-        keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       object: {
         type: "Object",
         default: { object: "Object" },
         kind: "expanded",
-        valueLoc: { end: { column: 26, line: 6 }, start: { column: 20, line: 6 } },
-        keyLoc: { end: { column: 18, line: 6 }, start: { column: 14, line: 6 } },
       },
       boolean: {
         type: "Boolean",
         default: true,
         kind: "expanded",
-        valueLoc: { end: { column: 28, line: 7 }, start: { column: 21, line: 7 } },
-        keyLoc: { end: { column: 19, line: 7 }, start: { column: 15, line: 7 } }
       },
       array: {
         type: "Array",
         default: ["Array"],
         kind: "expanded",
-        valueLoc: { end: { column: 24, line: 8 }, start: { column: 19, line: 8 } },
-        keyLoc: { end: { column: 17, line: 8 }, start: { column: 13, line: 8 } }
       },
       number: {
         type: "Number",
         default: 1,
         kind: "expanded",
-        valueLoc: { end: { column: 26, line: 9 }, start: { column: 20, line: 9 } },
-        keyLoc: { end: { column: 18, line: 9 }, start: { column: 14, line: 9 } }
       },
     })
   })
@@ -323,15 +273,11 @@ describe("with JS Syntax", () => {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
         kind: "expanded",
-        valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
-        keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
         kind: "expanded",
-        valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } },
-        keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } }
       },
     })
   })

--- a/test/parser/javascript.test.ts
+++ b/test/parser/javascript.test.ts
@@ -1,6 +1,7 @@
 import dedent from "dedent"
 import { describe, test, expect } from "vitest"
 import { parseController } from "../helpers/parse"
+import { extractLoc } from "../helpers/matchers"
 
 import { Project } from "../../src/project"
 import { SourceFile } from "../../src/source_file"
@@ -76,32 +77,49 @@ describe("with JS Syntax", () => {
     `
     const controller = parseController(code, "value_controller.js")
 
-    expect(controller.valueDefinitionsMap).toEqual({
-      array: {
-        type: "Array",
-        default: [],
-        kind: "shorthand",
-      },
-      boolean: {
-        type: "Boolean",
-        default: false,
-        kind: "shorthand",
-      },
-      number: {
-        type: "Number",
-        default: 0,
-        kind: "shorthand",
-      },
-      object: {
-        type: "Object",
-        default: {},
-        kind: "shorthand",
-      },
-      string: {
-        type: "String",
-        default: "",
-        kind: "shorthand",
-      },
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([8, 4, 8, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([8, 11, 8, 16])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([8, 11, 8, 16])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [],
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.keyLoc)).toEqual([7, 4, 7, 11])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.valueLoc)).toEqual([7, 13, 7, 20])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.typeLoc)).toEqual([7, 13, 7, 20])
+    expect(controller.valueDefinitionsMap.boolean.definition).toEqual({
+      type: "Boolean",
+      default: false,
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.number.keyLoc)).toEqual([9, 4, 9, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.number.valueLoc)).toEqual([9, 12, 9, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.number.typeLoc)).toEqual([9, 12, 9, 18])
+    expect(controller.valueDefinitionsMap.number.definition).toEqual({
+      type: "Number",
+      default: 0,
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([6, 4, 6, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([6, 12, 6, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([6, 12, 6, 18])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: {},
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([5, 12, 5, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([5, 12, 5, 18])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "",
+      kind: "shorthand",
     })
   })
 
@@ -121,32 +139,49 @@ describe("with JS Syntax", () => {
     `
     const controller = parseController(code, "value_controller.js")
 
-    expect(controller.valueDefinitionsMap).toEqual({
-      string: {
-        type: "String",
-        default: "string",
-        kind: "expanded",
-      },
-      object: {
-        type: "Object",
-        default: { object: "Object" },
-        kind: "expanded",
-      },
-      boolean: {
-        type: "Boolean",
-        default: true,
-        kind: "expanded",
-      },
-      array: {
-        type: "Array",
-        default: ["Array"],
-        kind: "expanded",
-      },
-      number: {
-        type: "Number",
-        default: 1,
-        kind: "expanded",
-      },
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([8, 4, 8, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([8, 11, 8, 46])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([8, 19, 8, 24])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: ["Array"],
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.keyLoc)).toEqual([7, 4, 7, 11])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.valueLoc)).toEqual([7, 13, 7, 45])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.typeLoc)).toEqual([7, 21, 7, 28])
+    expect(controller.valueDefinitionsMap.boolean.definition).toEqual({
+      type: "Boolean",
+      default: true,
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.number.keyLoc)).toEqual([9, 4, 9, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.number.valueLoc)).toEqual([9, 12, 9, 40])
+    expect(extractLoc(controller.valueDefinitionsMap.number.typeLoc)).toEqual([9, 20, 9, 26])
+    expect(controller.valueDefinitionsMap.number.definition).toEqual({
+      type: "Number",
+      default: 1,
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([6, 4, 6, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([6, 12, 6, 59])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([6, 20, 6, 26])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: { object: "Object" },
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([5, 12, 5, 47])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([5, 20, 5, 26])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "string",
+      kind: "expanded",
     })
   })
 
@@ -268,17 +303,22 @@ describe("with JS Syntax", () => {
     `
     const controller = parseController(code, "value_controller.js")
 
-    expect(controller.valueDefinitionsMap).toEqual({
-      object: {
-        type: "Object",
-        default: { object: { some: { more: { levels: {} } } } },
-        kind: "expanded",
-      },
-      array: {
-        type: "Array",
-        default: [["Array", "with", ["nested", ["values"]]]],
-        kind: "expanded",
-      },
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([5, 12, 5, 85])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([5, 20, 5, 26])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: { object: { some: { more: { levels: {} } } } },
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([6, 4, 6, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([6, 11, 6, 80])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([6, 19, 6, 24])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [["Array", "with", ["nested", ["values"]]]],
+      kind: "expanded",
     })
   })
 

--- a/test/parser/minified.test.ts
+++ b/test/parser/minified.test.ts
@@ -65,9 +65,9 @@ describe("compiled JavaScript", () => {
     expect(controller.hasErrors).toEqual(true)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Target "item"`)
     expect(controller.errors[0].loc.start.line).toEqual(4)
-    expect(controller.errors[0].loc.start.column).toEqual(19)
+    expect(controller.errors[0].loc.start.column).toEqual(20)
     expect(controller.errors[0].loc.end.line).toEqual(4)
-    expect(controller.errors[0].loc.end.column).toEqual(27)
+    expect(controller.errors[0].loc.end.column).toEqual(26)
 
     expect(controller.actionNames).toEqual([])
     expect(controller.targetNames).toEqual(["item", "item"])

--- a/test/parser/targets.test.ts
+++ b/test/parser/targets.test.ts
@@ -34,9 +34,9 @@ describe("parse targets", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Target "one"`)
     expect(controller.errors[0].loc.start.line).toEqual(4)
-    expect(controller.errors[0].loc.start.column).toEqual(19)
+    expect(controller.errors[0].loc.start.column).toEqual(27)
     expect(controller.errors[0].loc.end.line).toEqual(4)
-    expect(controller.errors[0].loc.end.column).toEqual(42)
+    expect(controller.errors[0].loc.end.column).toEqual(32)
   })
 
   test("duplicate static targets from parent", () => {
@@ -60,9 +60,9 @@ describe("parse targets", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Target "one". A parent controller already defines this Target.`)
     expect(controller.errors[0].loc.start.line).toEqual(8)
-    expect(controller.errors[0].loc.start.column).toEqual(19)
+    expect(controller.errors[0].loc.start.column).toEqual(20)
     expect(controller.errors[0].loc.end.line).toEqual(8)
-    expect(controller.errors[0].loc.end.column).toEqual(35)
+    expect(controller.errors[0].loc.end.column).toEqual(25)
   })
 
   test("assigns targets outside of class via member expression", () => {
@@ -276,8 +276,8 @@ describe("parse targets", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Target "output"`)
     expect(controller.errors[0].loc.start.line).toEqual(6)
-    expect(controller.errors[0].loc.start.column).toEqual(19)
+    expect(controller.errors[0].loc.start.column).toEqual(20)
     expect(controller.errors[0].loc.end.line).toEqual(6)
-    expect(controller.errors[0].loc.end.column).toEqual(29)
+    expect(controller.errors[0].loc.end.column).toEqual(28)
   })
 })

--- a/test/parser/typescript.test.ts
+++ b/test/parser/typescript.test.ts
@@ -1,6 +1,7 @@
 import dedent from "dedent"
 import { describe, test, expect } from "vitest"
 import { parseController } from "../helpers/parse"
+import { extractLoc } from "../helpers/matchers"
 
 import { Project } from "../../src/project"
 import { SourceFile } from "../../src/source_file"
@@ -75,32 +76,49 @@ describe("with TS Syntax", () => {
     `
     const controller = parseController(code, "value_controller.ts")
 
-    expect(controller.valueDefinitionsMap).toEqual({
-      array: {
-        type: "Array",
-        default: [],
-        kind: "shorthand",
-      },
-      boolean: {
-        type: "Boolean",
-        default: false,
-        kind: "shorthand",
-      },
-      number: {
-        type: "Number",
-        default: 0,
-        kind: "shorthand",
-      },
-      object: {
-        type: "Object",
-        default: {},
-        kind: "shorthand",
-      },
-      string: {
-        type: "String",
-        default: "",
-        kind: "shorthand",
-      },
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([8, 4, 8, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([8, 11, 8, 16])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([8, 11, 8, 16])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [],
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.keyLoc)).toEqual([7, 4, 7, 11])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.valueLoc)).toEqual([7, 13, 7, 20])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.typeLoc)).toEqual([7, 13, 7, 20])
+    expect(controller.valueDefinitionsMap.boolean.definition).toEqual({
+      type: "Boolean",
+      default: false,
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.number.keyLoc)).toEqual([9, 4, 9, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.number.valueLoc)).toEqual([9, 12, 9, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.number.typeLoc)).toEqual([9, 12, 9, 18])
+    expect(controller.valueDefinitionsMap.number.definition).toEqual({
+      type: "Number",
+      default: 0,
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([6, 4, 6, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([6, 12, 6, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([6, 12, 6, 18])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: {},
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([5, 12, 5, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([5, 12, 5, 18])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "",
+      kind: "shorthand",
     })
   })
 
@@ -126,32 +144,49 @@ describe("with TS Syntax", () => {
     `
     const controller = parseController(code, "value_controller.ts")
 
-    expect(controller.valueDefinitionsMap).toEqual({
-      string: {
-        type: "String",
-        default: "string",
-        kind: "expanded",
-      },
-      object: {
-        type: "Object",
-        default: { object: "Object" },
-        kind: "expanded",
-      },
-      boolean: {
-        type: "Boolean",
-        default: true,
-        kind: "expanded",
-      },
-      array: {
-        type: "Array",
-        default: ["Array"],
-        kind: "expanded",
-      },
-      number: {
-        type: "Number",
-        default: 1,
-        kind: "expanded",
-      },
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([8, 4, 8, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([8, 11, 8, 46])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([8, 19, 8, 24])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: ["Array"],
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.keyLoc)).toEqual([7, 4, 7, 11])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.valueLoc)).toEqual([7, 13, 7, 45])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.typeLoc)).toEqual([7, 21, 7, 28])
+    expect(controller.valueDefinitionsMap.boolean.definition).toEqual({
+      type: "Boolean",
+      default: true,
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.number.keyLoc)).toEqual([9, 4, 9, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.number.valueLoc)).toEqual([9, 12, 9, 40])
+    expect(extractLoc(controller.valueDefinitionsMap.number.typeLoc)).toEqual([9, 20, 9, 26])
+    expect(controller.valueDefinitionsMap.number.definition).toEqual({
+      type: "Number",
+      default: 1,
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([6, 4, 6, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([6, 12, 6, 59])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([6, 20, 6, 26])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: { object: "Object" },
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([5, 12, 5, 47])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([5, 20, 5, 26])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "string",
+      kind: "expanded",
     })
   })
 
@@ -245,17 +280,22 @@ describe("with TS Syntax", () => {
     `
     const controller = parseController(code, "value_controller.js")
 
-    expect(controller.valueDefinitionsMap).toEqual({
-      object: {
-        type: "Object",
-        default: { object: { some: { more: { levels: {} } } } },
-        kind: "expanded",
-      },
-      array: {
-        type: "Array",
-        default: [["Array", "with", ["nested", ["values"]]]],
-        kind: "expanded",
-      },
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([5, 12, 5, 85])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([5, 20, 5, 26])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: { object: { some: { more: { levels: {} } } } },
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([6, 4, 6, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([6, 11, 6, 80])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([6, 19, 6, 24])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [["Array", "with", ["nested", ["values"]]]],
+      kind: "expanded",
     })
   })
 

--- a/test/parser/typescript.test.ts
+++ b/test/parser/typescript.test.ts
@@ -80,66 +80,26 @@ describe("with TS Syntax", () => {
         type: "Array",
         default: [],
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 9, line: 8 },
-          start: { column: 4, line: 8 },
-        },
-        valueLoc: {
-          end: { column: 16, line: 8 },
-          start: { column: 11, line: 8 },
-        },
       },
       boolean: {
         type: "Boolean",
         default: false,
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 11, line: 7 },
-          start: { column: 4, line: 7 },
-        },
-        valueLoc: {
-          end: { column: 20, line: 7 },
-          start: { column: 13, line: 7 },
-        },
       },
       number: {
         type: "Number",
         default: 0,
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 9 },
-          start: { column: 4, line: 9 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 9 },
-          start: { column: 12, line: 9 },
-        },
       },
       object: {
         type: "Object",
         default: {},
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 6 },
-          start: { column: 4, line: 6 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 6 },
-          start: { column: 12, line: 6 },
-        },
       },
       string: {
         type: "String",
         default: "",
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 5 },
-          start: { column: 4, line: 5 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 5 },
-          start: { column: 12, line: 5 },
-        },
       },
     })
   })
@@ -171,35 +131,26 @@ describe("with TS Syntax", () => {
         type: "String",
         default: "string",
         kind: "expanded",
-        valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
-        keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       object: {
         type: "Object",
         default: { object: "Object" },
         kind: "expanded",
-        valueLoc: { end: { column: 26, line: 6 }, start: { column: 20, line: 6 } },
-        keyLoc: { end: { column: 18, line: 6 }, start: { column: 14, line: 6 } } },
+      },
       boolean: {
         type: "Boolean",
         default: true,
         kind: "expanded",
-        valueLoc: { end: { column: 28, line: 7 }, start: { column: 21, line: 7 } },
-        keyLoc: { end: { column: 19, line: 7 }, start: { column: 15, line: 7 } }
       },
       array: {
         type: "Array",
         default: ["Array"],
         kind: "expanded",
-        valueLoc: { end: { column: 24, line: 8 }, start: { column: 19, line: 8 } },
-        keyLoc: { end: { column: 17, line: 8 }, start: { column: 13, line: 8 } }
       },
       number: {
         type: "Number",
         default: 1,
         kind: "expanded",
-        valueLoc: { end: { column: 26, line: 9 }, start: { column: 20, line: 9 } },
-        keyLoc: { end: { column: 18, line: 9 }, start: { column: 14, line: 9 } }
       },
     })
   })
@@ -299,15 +250,11 @@ describe("with TS Syntax", () => {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
         kind: "expanded",
-        valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } },
-        keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
         kind: "expanded",
-        valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } },
-        keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } }
       },
     })
   })

--- a/test/parser/values.test.ts
+++ b/test/parser/values.test.ts
@@ -1,6 +1,7 @@
 import dedent from "dedent"
 import { describe, test, expect } from "vitest"
 import { parseController } from "../helpers/parse"
+import { extractLoc } from "../helpers/matchers"
 
 describe("parse values", () => {
   test("static", () => {
@@ -21,32 +22,50 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.js")
 
     expect(controller.isTyped).toBeFalsy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      array: {
-        type: "Array",
-        default: [],
-        kind: "shorthand",
-      },
-      boolean: {
-        type: "Boolean",
-        default: false,
-        kind: "shorthand",
-      },
-      number: {
-        type: "Number",
-        default: 0,
-        kind: "shorthand",
-      },
-      object: {
-        type: "Object",
-        default: {},
-        kind: "shorthand",
-      },
-      string: {
-        type: "String",
-        default: "",
-        kind: "shorthand",
-      },
+
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([8, 4, 8, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([8, 11, 8, 16])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([8, 11, 8, 16])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [],
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.keyLoc)).toEqual([7, 4, 7, 11])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.valueLoc)).toEqual([7, 13, 7, 20])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.typeLoc)).toEqual([7, 13, 7, 20])
+    expect(controller.valueDefinitionsMap.boolean.definition).toEqual({
+      type: "Boolean",
+      default: false,
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.number.keyLoc)).toEqual([9, 4, 9, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.number.valueLoc)).toEqual([9, 12, 9, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.number.typeLoc)).toEqual([9, 12, 9, 18])
+    expect(controller.valueDefinitionsMap.number.definition).toEqual({
+      type: "Number",
+      default: 0,
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([6, 4, 6, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([6, 12, 6, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([6, 12, 6, 18])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: {},
+      kind: "shorthand",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([5, 12, 5, 18])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([5, 12, 5, 18])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "",
+      kind: "shorthand",
     })
   })
 
@@ -68,32 +87,50 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.js")
 
     expect(controller.isTyped).toBeFalsy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      string: {
-        type: "String",
-        default: "string",
-        kind: "expanded",
-      },
-      object: {
-        type: "Object",
-        default: { object: "Object" },
-        kind: "expanded",
-      },
-      boolean: {
-        type: "Boolean",
-        default: true,
-        kind: "expanded",
-      },
-      array: {
-        type: "Array",
-        default: ["Array"],
-        kind: "expanded",
-      },
-      number: {
-        type: "Number",
-        default: 1,
-        kind: "expanded",
-      },
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([5, 12, 5, 47])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([5, 20, 5, 26])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "string",
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([6, 4, 6, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([6, 12, 6, 59])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([6, 20, 6, 26])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: { object: "Object" },
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.keyLoc)).toEqual([7, 4, 7, 11])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.valueLoc)).toEqual([7, 13, 7, 45])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.typeLoc)).toEqual([7, 21, 7, 28])
+    expect(controller.valueDefinitionsMap.boolean.definition).toEqual({
+      type: "Boolean",
+      default: true,
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([8, 4, 8, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([8, 11, 8, 46])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([8, 19, 8, 24])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: ["Array"],
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.number.keyLoc)).toEqual([9, 4, 9, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.number.valueLoc)).toEqual([9, 12, 9, 40])
+    expect(extractLoc(controller.valueDefinitionsMap.number.typeLoc)).toEqual([9, 20, 9, 26])
+    expect(controller.valueDefinitionsMap.number.definition).toEqual({
+      type: "Number",
+      default: 1,
+      kind: "expanded",
     })
   })
 
@@ -117,10 +154,7 @@ describe("parse values", () => {
     expect(controller.hasErrors).toBeTruthy()
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one"`)
-    expect(controller.errors[0].loc.start.line).toEqual(6)
-    expect(controller.errors[0].loc.start.column).toEqual(4)
-    expect(controller.errors[0].loc.end.line).toEqual(6)
-    expect(controller.errors[0].loc.end.column).toEqual(7)
+    expect(extractLoc(controller.errors[0].loc)).toEqual([5, 4, 5, 7])
   })
 
   test("duplicate static values from parent", () => {
@@ -148,10 +182,7 @@ describe("parse values", () => {
     expect(controller.hasErrors).toBeTruthy()
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one". A parent controller already defines this Value.`)
-    expect(controller.errors[0].loc.start.line).toEqual(11)
-    expect(controller.errors[0].loc.start.column).toEqual(4)
-    expect(controller.errors[0].loc.end.line).toEqual(11)
-    expect(controller.errors[0].loc.end.column).toEqual(7)
+    expect(extractLoc(controller.errors[0].loc)).toEqual([11, 4, 11, 7])
   })
 
   test("assigns values outside of class via member expression", () => {
@@ -189,7 +220,7 @@ describe("parse values", () => {
         @Value(String) oneValue!: string;
 
         static values = {
-          one: { type: "String", default: ""}
+          one: { type: "String", default: "" }
         }
       }
     `
@@ -201,10 +232,7 @@ describe("parse values", () => {
     expect(controller.hasErrors).toBeTruthy()
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one"`)
-    expect(controller.errors[0].loc.start.line).toEqual(9)
-    expect(controller.errors[0].loc.start.column).toEqual(4)
-    expect(controller.errors[0].loc.end.line).toEqual(9)
-    expect(controller.errors[0].loc.end.column).toEqual(7)
+    expect(extractLoc(controller.errors[0].loc)).toEqual([9, 4, 9, 7])
   })
 
   test("duplicate static values mixed with decorator", () => {
@@ -229,10 +257,7 @@ describe("parse values", () => {
     expect(controller.hasErrors).toBeTruthy()
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one"`)
-    expect(controller.errors[0].loc.start.line).toEqual(7)
-    expect(controller.errors[0].loc.start.column).toEqual(4)
-    expect(controller.errors[0].loc.end.line).toEqual(7)
-    expect(controller.errors[0].loc.end.column).toEqual(7)
+    expect(extractLoc(controller.errors[0].loc)).toEqual([7, 4, 7, 7])
   })
 
   test("decorated", () => {
@@ -253,32 +278,50 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.ts")
 
     expect(controller.isTyped).toBeTruthy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      array: {
-        type: "Array",
-        default: [],
-        kind: "decorator",
-      },
-      boolean: {
-        type: "Boolean",
-        default: false,
-        kind: "decorator",
-      },
-      number: {
-        type: "Number",
-        default: 0,
-        kind: "decorator",
-      },
-      object: {
-        type: "Object",
-        default: {},
-        kind: "decorator",
-      },
-      string: {
-        type: "String",
-        default: "",
-        kind: "decorator",
-      },
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([6, 17, 6, 28])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([6, 2, 6, 38])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([6, 2, 6, 16])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "",
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([7, 17, 7, 28])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([7, 2, 7, 34])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([7, 2, 7, 16])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: {},
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.keyLoc)).toEqual([8, 18, 8, 30])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.valueLoc)).toEqual([8, 2, 8, 41])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.typeLoc)).toEqual([8, 2, 8, 17])
+    expect(controller.valueDefinitionsMap.boolean.definition).toEqual({
+      type: "Boolean",
+      default: false,
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([9, 16, 9, 26])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([9, 2, 9, 32])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([9, 2, 9, 15])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [],
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.number.keyLoc)).toEqual([10, 17, 10, 28])
+    expect(extractLoc(controller.valueDefinitionsMap.number.valueLoc)).toEqual([10, 2, 10, 38])
+    expect(extractLoc(controller.valueDefinitionsMap.number.typeLoc)).toEqual([10, 2, 10, 16])
+    expect(controller.valueDefinitionsMap.number.definition).toEqual({
+      type: "Number",
+      default: 0,
+      kind: "decorator",
     })
   })
 
@@ -300,32 +343,50 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.ts")
 
     expect(controller.isTyped).toBeTruthy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      array: {
-        type: "Array",
-        default: [1, 2, 3],
-        kind: "decorator",
-      },
-      boolean: {
-        type: "Boolean",
-        default: true,
-        kind: "decorator",
-      },
-      number: {
-        type: "Number",
-        default: 10,
-        kind: "decorator",
-      },
-      object: {
-        type: "Object",
-        default: { hello: "world" },
-        kind: "decorator",
-      },
-      string: {
-        type: "String",
-        default: "string",
-        kind: "decorator",
-      },
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([6, 17, 6, 28])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([6, 32, 6, 40])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([6, 2, 6, 16])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "string",
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([7, 17, 7, 28])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([7, 32, 7, 50])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([7, 2, 7, 16])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: { hello: "world" },
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.keyLoc)).toEqual([8, 18, 8, 30])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.valueLoc)).toEqual([8, 34, 8, 38])
+    expect(extractLoc(controller.valueDefinitionsMap.boolean.typeLoc)).toEqual([8, 2, 8, 17])
+    expect(controller.valueDefinitionsMap.boolean.definition).toEqual({
+      type: "Boolean",
+      default: true,
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([9, 16, 9, 26])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([9, 30, 9, 39])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([9, 2, 9, 15])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [1, 2, 3],
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.number.keyLoc)).toEqual([10, 17, 10, 28])
+    expect(extractLoc(controller.valueDefinitionsMap.number.valueLoc)).toEqual([10, 32, 10, 34])
+    expect(extractLoc(controller.valueDefinitionsMap.number.typeLoc)).toEqual([10, 2, 10, 16])
+    expect(controller.valueDefinitionsMap.number.definition).toEqual({
+      type: "Number",
+      default: 10,
+      kind: "decorator",
     })
   })
 
@@ -344,17 +405,23 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.js")
 
     expect(controller.isTyped).toBeFalsy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      object: {
-        type: "Object",
-        default: { object: { some: { more: { levels: {} } } } },
-        kind: "expanded",
-      },
-      array: {
-        type: "Array",
-        default: [["Array", "with", ["nested", ["values"]]]],
-        kind: "expanded",
-      },
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([5, 4, 5, 10])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([5, 12, 5, 85])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([5, 20, 5, 26])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: { object: { some: { more: { levels: {} } } } },
+      kind: "expanded",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([6, 4, 6, 9])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([6, 11, 6, 80])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([6, 19, 6, 24])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [["Array", "with", ["nested", ["values"]]]],
+      kind: "expanded",
     })
   })
 
@@ -373,17 +440,23 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.ts")
 
     expect(controller.isTyped).toBeTruthy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      array: {
-        type: "Array",
-        default: [["Array", "with", ["nested", ["values"]]]],
-        kind: "decorator",
-      },
-      object: {
-        type: "Object",
-        default: { object: { some: { more: { levels: {} } } } },
-        kind: "decorator",
-      },
+
+    expect(extractLoc(controller.valueDefinitionsMap.object.keyLoc)).toEqual([6, 17, 6, 28])
+    expect(extractLoc(controller.valueDefinitionsMap.object.valueLoc)).toEqual([6, 32, 6, 78])
+    expect(extractLoc(controller.valueDefinitionsMap.object.typeLoc)).toEqual([6, 2, 6, 16])
+    expect(controller.valueDefinitionsMap.object.definition).toEqual({
+      type: "Object",
+      default: { object: { some: { more: { levels: {} } } } },
+      kind: "decorator",
+    })
+
+    expect(extractLoc(controller.valueDefinitionsMap.array.keyLoc)).toEqual([7, 16, 7, 26])
+    expect(extractLoc(controller.valueDefinitionsMap.array.valueLoc)).toEqual([7, 30, 7, 73])
+    expect(extractLoc(controller.valueDefinitionsMap.array.typeLoc)).toEqual([7, 2, 7, 15])
+    expect(controller.valueDefinitionsMap.array.definition).toEqual({
+      type: "Array",
+      default: [["Array", "with", ["nested", ["values"]]]],
+      kind: "decorator",
     })
   })
 
@@ -401,12 +474,14 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.ts")
 
     expect(controller.isTyped).toBeFalsy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      string: {
-        type: "String",
-        default: "Number",
-        kind: "inferred",
-      },
+
+    expect(extractLoc(controller.valueDefinitionsMap.string.keyLoc)).toEqual([])
+    expect(extractLoc(controller.valueDefinitionsMap.string.valueLoc)).toEqual([])
+    expect(extractLoc(controller.valueDefinitionsMap.string.typeLoc)).toEqual([])
+    expect(controller.valueDefinitionsMap.string.definition).toEqual({
+      type: "String",
+      default: "Number",
+      kind: "inferred",
     })
   })
 
@@ -424,12 +499,13 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.ts")
 
     expect(controller.isTyped).toBeFalsy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      name: {
-        type: "String",
-        default: "",
-        kind: "shorthand",
-      },
+    expect(extractLoc(controller.valueDefinitionsMap.name.keyLoc)).toEqual([5, 4, 5, 8])
+    expect(extractLoc(controller.valueDefinitionsMap.name.valueLoc)).toEqual([5, 10, 5, 16])
+    expect(extractLoc(controller.valueDefinitionsMap.name.typeLoc)).toEqual([5, 10, 5, 16])
+    expect(controller.valueDefinitionsMap.name.definition).toEqual({
+      type: "String",
+      default: "",
+      kind: "shorthand",
     })
   })
 
@@ -450,12 +526,14 @@ describe("parse values", () => {
     const controller = parseController(code, "value_controller.ts")
 
     expect(controller.isTyped).toBeFalsy()
-    expect(controller.valueDefinitionsMap).toEqual({
-      name: {
-        type: "String",
-        default: "Stimulus",
-        kind: "expanded",
-      },
+
+    expect(extractLoc(controller.valueDefinitionsMap.name.keyLoc)).toEqual([5, 4, 5, 8])
+    expect(extractLoc(controller.valueDefinitionsMap.name.valueLoc)).toEqual([5, 10, 8, 5])
+    expect(extractLoc(controller.valueDefinitionsMap.name.typeLoc)).toEqual([6, 12, 6, 18])
+    expect(controller.valueDefinitionsMap.name.definition).toEqual({
+      type: "String",
+      default: "Stimulus",
+      kind: "expanded",
     })
   })
 })

--- a/test/parser/values.test.ts
+++ b/test/parser/values.test.ts
@@ -154,7 +154,7 @@ describe("parse values", () => {
     expect(controller.hasErrors).toBeTruthy()
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one"`)
-    expect(extractLoc(controller.errors[0].loc)).toEqual([5, 4, 5, 7])
+    expect(extractLoc(controller.errors[0].loc)).toEqual([6, 4, 6, 7])
   })
 
   test("duplicate static values from parent", () => {

--- a/test/parser/values.test.ts
+++ b/test/parser/values.test.ts
@@ -26,66 +26,26 @@ describe("parse values", () => {
         type: "Array",
         default: [],
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 9, line: 8 },
-          start: { column: 4, line: 8 },
-        },
-        valueLoc: {
-          end: { column: 16, line: 8 },
-          start: { column: 11, line: 8 },
-        },
       },
       boolean: {
         type: "Boolean",
         default: false,
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 11, line: 7 },
-          start: { column: 4, line: 7 },
-        },
-        valueLoc: {
-          end: { column: 20, line: 7 },
-          start: { column: 13, line: 7 },
-        },
       },
       number: {
         type: "Number",
         default: 0,
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 9 },
-          start: { column: 4, line: 9 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 9 },
-          start: { column: 12, line: 9 },
-        },
       },
       object: {
         type: "Object",
         default: {},
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 6 },
-          start: { column: 4, line: 6 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 6 },
-          start: { column: 12, line: 6 },
-        },
       },
       string: {
         type: "String",
         default: "",
         kind: "shorthand",
-        keyLoc: {
-          end: { column: 10, line: 5 },
-          start: { column: 4, line: 5 },
-        },
-        valueLoc: {
-          end: { column: 18, line: 5 },
-          start: { column: 12, line: 5 },
-        },
       },
     })
   })
@@ -113,66 +73,26 @@ describe("parse values", () => {
         type: "String",
         default: "string",
         kind: "expanded",
-        valueLoc: {
-          end: { column: 26, line: 5 },
-          start: { column: 20, line: 5 },
-        },
-        keyLoc: {
-          end: { column: 18, line: 5 },
-          start: { column: 14, line: 5 },
-        },
       },
       object: {
         type: "Object",
         default: { object: "Object" },
         kind: "expanded",
-        valueLoc: {
-          end: { column: 26, line: 6 },
-          start: { column: 20, line: 6 },
-        },
-        keyLoc: {
-          end: { column: 18, line: 6 },
-          start: { column: 14, line: 6 },
-        },
       },
       boolean: {
         type: "Boolean",
         default: true,
         kind: "expanded",
-        valueLoc: {
-          end: { column: 28, line: 7 },
-          start: { column: 21, line: 7 },
-        },
-        keyLoc: {
-          end: { column: 19, line: 7 },
-          start: { column: 15, line: 7 },
-        },
       },
       array: {
         type: "Array",
         default: ["Array"],
         kind: "expanded",
-        valueLoc: {
-          end: { column: 24, line: 8 },
-          start: { column: 19, line: 8 },
-        },
-        keyLoc: {
-          end: { column: 17, line: 8 },
-          start: { column: 13, line: 8 },
-        },
       },
       number: {
         type: "Number",
         default: 1,
         kind: "expanded",
-        valueLoc: {
-          end: { column: 26, line: 9 },
-          start: { column: 20, line: 9 },
-        },
-        keyLoc: {
-          end: { column: 18, line: 9 },
-          start: { column: 14, line: 9 },
-        },
       },
     })
   })
@@ -198,9 +118,9 @@ describe("parse values", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one"`)
     expect(controller.errors[0].loc.start.line).toEqual(6)
-    expect(controller.errors[0].loc.start.column).toEqual(11)
+    expect(controller.errors[0].loc.start.column).toEqual(4)
     expect(controller.errors[0].loc.end.line).toEqual(6)
-    expect(controller.errors[0].loc.end.column).toEqual(15)
+    expect(controller.errors[0].loc.end.column).toEqual(7)
   })
 
   test("duplicate static values from parent", () => {
@@ -229,9 +149,9 @@ describe("parse values", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one". A parent controller already defines this Value.`)
     expect(controller.errors[0].loc.start.line).toEqual(11)
-    expect(controller.errors[0].loc.start.column).toEqual(11)
+    expect(controller.errors[0].loc.start.column).toEqual(4)
     expect(controller.errors[0].loc.end.line).toEqual(11)
-    expect(controller.errors[0].loc.end.column).toEqual(15)
+    expect(controller.errors[0].loc.end.column).toEqual(7)
   })
 
   test("assigns values outside of class via member expression", () => {
@@ -282,9 +202,9 @@ describe("parse values", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one"`)
     expect(controller.errors[0].loc.start.line).toEqual(9)
-    expect(controller.errors[0].loc.start.column).toEqual(11)
+    expect(controller.errors[0].loc.start.column).toEqual(4)
     expect(controller.errors[0].loc.end.line).toEqual(9)
-    expect(controller.errors[0].loc.end.column).toEqual(15)
+    expect(controller.errors[0].loc.end.column).toEqual(7)
   })
 
   test("duplicate static values mixed with decorator", () => {
@@ -310,9 +230,9 @@ describe("parse values", () => {
     expect(controller.errors).toHaveLength(1)
     expect(controller.errors[0].message).toEqual(`Duplicate definition of Stimulus Value "one"`)
     expect(controller.errors[0].loc.start.line).toEqual(7)
-    expect(controller.errors[0].loc.start.column).toEqual(11)
+    expect(controller.errors[0].loc.start.column).toEqual(4)
     expect(controller.errors[0].loc.end.line).toEqual(7)
-    expect(controller.errors[0].loc.end.column).toEqual(15)
+    expect(controller.errors[0].loc.end.column).toEqual(7)
   })
 
   test("decorated", () => {
@@ -338,36 +258,26 @@ describe("parse values", () => {
         type: "Array",
         default: [],
         kind: "decorator",
-        keyLoc: { end: { column: 15, line: 9 }, start: { column: 2, line: 9 } },
-        valueLoc: { end: { column: 32, line: 9 }, start: { column: 2, line: 9 } },
       },
       boolean: {
         type: "Boolean",
         default: false,
         kind: "decorator",
-        keyLoc: { end: { column: 17, line: 8 }, start: { column: 2, line: 8 } },
-        valueLoc: { end: { column: 41, line: 8 }, start: { column: 2, line: 8 } },
       },
       number: {
         type: "Number",
         default: 0,
         kind: "decorator",
-        keyLoc: { end: { column: 16, line: 10 }, start: { column: 2, line: 10 } },
-        valueLoc: { end: { column: 38, line: 10 }, start: { column: 2, line: 10 } },
       },
       object: {
         type: "Object",
         default: {},
         kind: "decorator",
-        keyLoc: { end: { column: 16, line: 7 }, start: { column: 2, line: 7 } },
-        valueLoc: { end: { column: 34, line: 7 }, start: { column: 2, line: 7 } },
       },
       string: {
         type: "String",
         default: "",
         kind: "decorator",
-        keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
-        valueLoc: { end: { column: 38, line: 6 }, start: { column: 2, line: 6 } },
       },
     })
   })
@@ -395,36 +305,26 @@ describe("parse values", () => {
         type: "Array",
         default: [1, 2, 3],
         kind: "decorator",
-        keyLoc: { end: { column: 15, line: 9 }, start: { column: 2, line: 9 } },
-        valueLoc: { end: { column: 39, line: 9 }, start: { column: 2, line: 9 } },
       },
       boolean: {
         type: "Boolean",
         default: true,
         kind: "decorator",
-        keyLoc: { end: { column: 17, line: 8 }, start: { column: 2, line: 8 } },
-        valueLoc: { end: { column: 38, line: 8 }, start: { column: 2, line: 8 } },
       },
       number: {
         type: "Number",
         default: 10,
         kind: "decorator",
-        keyLoc: { end: { column: 16, line: 10 }, start: { column: 2, line: 10 } },
-        valueLoc: { end: { column: 34, line: 10 }, start: { column: 2, line: 10 } },
       },
       object: {
         type: "Object",
         default: { hello: "world" },
         kind: "decorator",
-        keyLoc: { end: { column: 16, line: 7 }, start: { column: 2, line: 7 } },
-        valueLoc: { end: { column: 50, line: 7 }, start: { column: 2, line: 7 } },
       },
       string: {
         type: "String",
         default: "string",
         kind: "decorator",
-        keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
-        valueLoc: { end: { column: 40, line: 6 }, start: { column: 2, line: 6 } },
       },
     })
   })
@@ -449,15 +349,11 @@ describe("parse values", () => {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
         kind: "expanded",
-        keyLoc: { end: { column: 18, line: 5 }, start: { column: 14, line: 5 } },
-        valueLoc: { end: { column: 26, line: 5 }, start: { column: 20, line: 5 } }
       },
       array: {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
         kind: "expanded",
-        keyLoc: { end: { column: 17, line: 6 }, start: { column: 13, line: 6 } },
-        valueLoc: { end: { column: 24, line: 6 }, start: { column: 19, line: 6 } }
       },
     })
   })
@@ -482,15 +378,11 @@ describe("parse values", () => {
         type: "Array",
         default: [["Array", "with", ["nested", ["values"]]]],
         kind: "decorator",
-        keyLoc: { end: { column: 15, line: 7 }, start: { column: 2, line: 7 } },
-        valueLoc: { end: { column: 73, line: 7 }, start: { column: 2, line: 7 } },
       },
       object: {
         type: "Object",
         default: { object: { some: { more: { levels: {} } } } },
         kind: "decorator",
-        keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
-        valueLoc: { end: { column: 78, line: 6 }, start: { column: 2, line: 6 } },
       },
     })
   })
@@ -514,8 +406,6 @@ describe("parse values", () => {
         type: "String",
         default: "Number",
         kind: "inferred",
-        keyLoc: { end: { column: 16, line: 6 }, start: { column: 2, line: 6 } },
-        valueLoc: { end: { column: 78, line: 6 }, start: { column: 2, line: 6 } },
       },
     })
   })
@@ -539,8 +429,6 @@ describe("parse values", () => {
         type: "String",
         default: "",
         kind: "shorthand",
-        keyLoc: { end: { column: 8, line: 5 }, start: { column: 4, line: 5 } },
-        valueLoc: { end: { column: 16, line: 5 }, start: { column: 10, line: 5 } },
       },
     })
   })
@@ -567,8 +455,6 @@ describe("parse values", () => {
         type: "String",
         default: "Stimulus",
         kind: "expanded",
-        keyLoc: { end: { column: 10, line: 6 }, start: { column: 6, line: 6 } },
-        valueLoc: { end: { column: 18, line: 6 }, start: { column: 12, line: 6 } },
       },
     })
   })


### PR DESCRIPTION
Hey @marcoroth,

Based on our discussion, I'm trying to add the various Loc's as getters on ValueDefinition. Here is a draft for you to see what I'm doing. The `TypeLoc` getter seems to be challenging as the `this.node` value of the valuedefinition can have various different syntaxes and we would have to filter through `ObjectExpression` type or `Literal` types.
