### PR TITLE
Rename `controllersFiles` to `controllerIndexFiles` on `Project`

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -28,7 +28,7 @@ export class Project {
   public _controllerRoots: Set<string> = new Set()
   public parser: Parser = new Parser(this)
   public applicationFile?: ApplicationFile
-  public controllersFiles: ControllersIndexFile[] = []
+  public controllersIndexFiles: ControllersIndexFile[] = []
 
   constructor(projectPath: string) {
     this.projectPath = projectPath
@@ -108,7 +108,7 @@ export class Project {
   }
 
   get calculatedControllerRoots() {
-    return this.controllersFiles.map(file => this.relativePath(file.path.split("/").slice(0, -1).join("/")))
+    return this.controllersIndexFiles.map(file => this.relativePath(file.path.split("/").slice(0, -1).join("/")))
   }
 
   get guessedControllerRoots() {
@@ -120,9 +120,9 @@ export class Project {
   }
 
   get registeredControllers(): RegisteredController[] {
-    if (this.controllersFiles.length === 0) return []
+    if (this.controllersIndexFiles.length === 0) return []
 
-    return this.controllersFiles.flatMap(file => file.registeredControllers)
+    return this.controllersIndexFiles.flatMap(file => file.registeredControllers)
   }
 
   get referencedNodeModulesLazy() {
@@ -247,13 +247,13 @@ export class Project {
     }
 
     controllersFiles.forEach(controllersFile =>
-      this.controllersFiles.push(new ControllersIndexFile(this, controllersFile))
+      this.controllersIndexFiles.push(new ControllersIndexFile(this, controllersFile))
     )
 
-    if (this.controllersFiles.length === 0) {
+    if (this.controllersIndexFiles.length === 0) {
       // TODO: we probably want to add an error to the project
     } else {
-      await Promise.allSettled(this.controllersFiles.map(file => file.analyze()))
+      await Promise.allSettled(this.controllersIndexFiles.map(file => file.analyze()))
     }
   }
 

--- a/test/system/bun.test.ts
+++ b/test/system/bun.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("bun")
 
 describe("System", () => {
   test("bun", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "register"]])

--- a/test/system/esbuild-rails-single-stimulus-file.test.ts
+++ b/test/system/esbuild-rails-single-stimulus-file.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("esbuild-rails-single-stimulus-file")
 
 describe("System", () => {
   test("esbuild-rails-single-stimulus-file", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toBeUndefined()
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/index.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeUndefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("Application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeUndefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("Application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "esbuild-rails"]])

--- a/test/system/esbuild-rails-with-viewcomponents-nested.test.ts
+++ b/test/system/esbuild-rails-with-viewcomponents-nested.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("esbuild-rails-with-viewcomponents-nested")
 
 describe("System", () => {
   test("esbuild-rails-with-viewcomponents-nested", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,15 +16,15 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(2)
+    expect(project.controllersIndexFiles.length).toEqual(2)
 
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/components/index.js")
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/components/index.js")
 
-    expect(project.controllersFiles[1].applicationImport).toBeDefined()
-    expect(project.controllersFiles[1].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[1].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles[1].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[1].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[1].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(3)
 

--- a/test/system/esbuild-rails-with-viewcomponents.test.ts
+++ b/test/system/esbuild-rails-with-viewcomponents.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("esbuild-rails-with-viewcomponents")
 
 describe("System", () => {
   test("esbuild-rails-with-viewcomponents", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,15 +16,15 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(2)
+    expect(project.controllersIndexFiles.length).toEqual(2)
 
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/components/index.js")
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/components/index.js")
 
-    expect(project.controllersFiles[1].applicationImport).toBeDefined()
-    expect(project.controllersFiles[1].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[1].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles[1].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[1].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[1].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(3)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([

--- a/test/system/esbuild-rails.test.ts
+++ b/test/system/esbuild-rails.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("esbuild-rails")
 
 describe("System", () => {
   test("esbuild-rails", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "esbuild-rails"]])

--- a/test/system/esbuild.test.ts
+++ b/test/system/esbuild.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("esbuild")
 
 describe("System", () => {
   test("esbuild", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "register"]])

--- a/test/system/importmap-laravel-eager.test.ts
+++ b/test/system/importmap-laravel-eager.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("importmap-laravel-eager")
 
 describe("System", () => {
   test("importmap-laravel-eager", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("Stimulus")
     expect(project.relativePath(project.applicationFile.path)).toEqual("resources/js/libs/stimulus.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("Stimulus")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("resources/js/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("Stimulus")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("resources/js/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "stimulus-loading-eager"]])

--- a/test/system/importmap-laravel-lazy.test.ts
+++ b/test/system/importmap-laravel-lazy.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("importmap-laravel-lazy")
 
 describe("System", () => {
   test("importmap-laravel-lazy", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("Stimulus")
     expect(project.relativePath(project.applicationFile.path)).toEqual("resources/js/libs/stimulus.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("Stimulus")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("resources/js/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("Stimulus")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("resources/js/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "stimulus-loading-lazy"]])

--- a/test/system/importmap-rails-eager.test.ts
+++ b/test/system/importmap-rails-eager.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("importmap-rails-eager")
 
 describe("System", () => {
   test("importmap-rails-eager", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "stimulus-loading-eager"]])

--- a/test/system/importmap-rails-lazy.test.ts
+++ b/test/system/importmap-rails-lazy.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("importmap-rails-lazy")
 
 describe("System", () => {
   test("importmap-rails-lazy", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "stimulus-loading-lazy"]])

--- a/test/system/multiple-exports-and-register.test.ts
+++ b/test/system/multiple-exports-and-register.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("multiple-exports-and-register")
 
 describe("System", () => {
   test("multiple-exports-and-register", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("StimulusApplication")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("AnotherSuperWeirdName")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("AnotherSuperWeirdName")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "register"]])

--- a/test/system/rollup.test.ts
+++ b/test/system/rollup.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("rollup")
 
 describe("System", () => {
   test("rollup", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "register"]])

--- a/test/system/shakapacker.test.ts
+++ b/test/system/shakapacker.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("shakapacker")
 
 describe("System", () => {
   test("shakapacker", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "stimulus-webpack-helpers"]])

--- a/test/system/vite-laravel.test.ts
+++ b/test/system/vite-laravel.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("vite-laravel")
 
 describe("System", () => {
   test("vite-laravel", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("Stimulus")
     expect(project.relativePath(project.applicationFile.path)).toEqual("resources/js/libs/stimulus.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("Stimulus")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("resources/js/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("Stimulus")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("resources/js/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "register"]])

--- a/test/system/vite-rails.test.ts
+++ b/test/system/vite-rails.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("vite-rails")
 
 describe("System", () => {
   test("vite-rails", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/frontend/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/frontend/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/frontend/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "stimulus-vite-helpers"]])

--- a/test/system/webpacker-rails-single-stimulus-file.test.ts
+++ b/test/system/webpacker-rails-single-stimulus-file.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("webpacker-rails-single-stimulus-file")
 
 describe("System", () => {
   test("webpacker-rails-single-stimulus-file", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toBeUndefined()
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/index.ts")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeUndefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("Application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.ts")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeUndefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("Application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.ts")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "stimulus-webpack-helpers"]])

--- a/test/system/webpacker.test.ts
+++ b/test/system/webpacker.test.ts
@@ -5,7 +5,7 @@ const project = setupProject("webpacker")
 
 describe("System", () => {
   test("webpacker", async () => {
-    expect(project.controllersFiles.length).toEqual(0)
+    expect(project.controllersIndexFiles.length).toEqual(0)
     expect(project.applicationFile).toBeUndefined()
     expect(project.registeredControllers.length).toEqual(0)
 
@@ -16,10 +16,10 @@ describe("System", () => {
     expect(project.applicationFile.exportedApplicationConstant).toEqual("application")
     expect(project.relativePath(project.applicationFile.path)).toEqual("app/javascript/controllers/application.js")
 
-    expect(project.controllersFiles.length).toEqual(1)
-    expect(project.controllersFiles[0].applicationImport).toBeDefined()
-    expect(project.controllersFiles[0].localApplicationConstant).toEqual("application")
-    expect(project.relativePath(project.controllersFiles[0].path)).toEqual("app/javascript/controllers/index.js")
+    expect(project.controllersIndexFiles.length).toEqual(1)
+    expect(project.controllersIndexFiles[0].applicationImport).toBeDefined()
+    expect(project.controllersIndexFiles[0].localApplicationConstant).toEqual("application")
+    expect(project.relativePath(project.controllersIndexFiles[0].path)).toEqual("app/javascript/controllers/index.js")
 
     expect(project.registeredControllers.length).toEqual(1)
     expect(project.registeredControllers.map(controller => [controller.identifier, controller.loadMode])).toEqual([["hello", "stimulus-webpack-helpers"]])


### PR DESCRIPTION
This pull request refactors the  `controllersFiles` Array to `controllerIndexFiles` on `Project` to be more in in-line with the actual [`ControllersIndexFile`](https://github.com/marcoroth/stimulus-parser/blob/3a9323697145379cf77ddb12131a75bbc3342a8d/src/controllers_index_file.ts#L14) class name.