### PR TITLE
Allow `stimulus` package name for controller definition

### DIFF
--- a/src/source_file.ts
+++ b/src/source_file.ts
@@ -220,7 +220,7 @@ export class SourceFile {
           const originalName = (original === "default") ? undefined : original
           const localName = specifier.local.name
           const source = ast.extractLiteral(node.source) as string
-          const isStimulusImport = (originalName === "Controller" && source === "@hotwired/stimulus")
+          const isStimulusImport = (originalName === "Controller" && ["@hotwired/stimulus", "stimulus"].includes(source))
 
           let type: ImportDeclarationType = "default"
 

--- a/test/source_file/class_declarations.test.ts
+++ b/test/source_file/class_declarations.test.ts
@@ -158,6 +158,26 @@ describe("SourceFile", () => {
       expect(something.superClass).toBeInstanceOf(StimulusControllerClassDeclaration)
     })
 
+    test("named class with superclass from Stimulus Controller import and old package name", async () => {
+      const code = dedent`
+        import { Controller } from "stimulus"
+        class Something extends Controller {}
+      `
+
+      const sourceFile = new SourceFile(project, "abc.js", code)
+      project.projectFiles.push(sourceFile)
+
+      await project.analyze()
+
+      const something = sourceFile.findClass("Something")
+
+      expect(something).toBeDefined()
+      expect(something.isStimulusDescendant).toBeTruthy()
+      expect(something.superClass).toBeDefined()
+      expect(something.superClass.isStimulusDescendant).toBeTruthy()
+      expect(something.superClass).toBeInstanceOf(StimulusControllerClassDeclaration)
+    })
+
     test("anonymous class assigned to variable from Stimulus Controller import", async () => {
       const code = dedent`
         import { Controller } from "@hotwired/stimulus"

--- a/test/source_file/import_declarations.test.ts
+++ b/test/source_file/import_declarations.test.ts
@@ -202,6 +202,26 @@ describe("SourceFile", async () => {
       expect(controller.type).toEqual("named")
     })
 
+    test("stimulus controller import with old package name", async () => {
+      const code = dedent`
+        import { Controller } from "stimulus"
+      `
+
+      const sourceFile = new SourceFile(project, "abc.js", code)
+      project.projectFiles.push(sourceFile)
+
+      await project.analyze()
+
+      const controller = sourceFile.findImport("Controller")
+
+      expect(controller.isRenamedImport).toEqual(false)
+      expect(controller.isStimulusImport).toEqual(true)
+      expect(controller.localName).toEqual("Controller")
+      expect(controller.originalName).toEqual("Controller")
+      expect(controller.source).toEqual("stimulus")
+      expect(controller.type).toEqual("named")
+    })
+
     test("stimulus controller import with alias", async () => {
       const code = dedent`
         import { Controller as StimulusController } from "@hotwired/stimulus"
@@ -219,6 +239,26 @@ describe("SourceFile", async () => {
       expect(controller.localName).toEqual("StimulusController")
       expect(controller.originalName).toEqual("Controller")
       expect(controller.source).toEqual("@hotwired/stimulus")
+      expect(controller.type).toEqual("named")
+    })
+
+    test("stimulus controller import with alias and old package name", async () => {
+      const code = dedent`
+        import { Controller as StimulusController } from "stimulus"
+      `
+
+      const sourceFile = new SourceFile(project, "abc.js", code)
+      project.projectFiles.push(sourceFile)
+
+      await project.analyze()
+
+      const controller = sourceFile.findImport("StimulusController")
+
+      expect(controller.isRenamedImport).toEqual(true)
+      expect(controller.isStimulusImport).toEqual(true)
+      expect(controller.localName).toEqual("StimulusController")
+      expect(controller.originalName).toEqual("Controller")
+      expect(controller.source).toEqual("stimulus")
       expect(controller.type).toEqual("named")
     })
   })


### PR DESCRIPTION
This pull request updates the detection of the Stimulus Controller import to also accept the "deprecated" `stimulus` package name.

Thanks to @rodrigolj for reporting this!