### PR TITLE
Upgrade to TypeScript 5.8.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "source-map": "^0.7.4",
     "ts-node": "^10.9.2",
     "tslib": "^2.6.2",
-    "typescript": "^5.5.3",
+    "typescript": "^5.8.0-beta",
     "vitest": "^3.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1107,10 +1107,10 @@ tslib@^2.6.2:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
-typescript@^5.5.3:
-  version "5.7.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.7.3.tgz#919b44a7dbb8583a9b856d162be24a54bf80073e"
-  integrity sha512-84MVSjMEHP+FQRPy3pX9sTVV/INIex71s9TL2Gm5FG/WG1SqXeKyZ0k7/blY/4FdOzI12CBy1vGc4og/eus0fw==
+typescript@^5.8.0-beta:
+  version "5.8.0-beta"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-5.8.0-beta.tgz#ba16fac5715be6540d01f0a9778f5eab7ae2ec61"
+  integrity sha512-7VGUiBOGi+BYhiuy3iITIgu6m2wVW2Vb4CW+OJsW6OJS/TgvezKbAN3WBfiSErE8QOLdce0ilm6VANMkzNWW1A==
 
 undici-types@~6.20.0:
   version "6.20.0"


### PR DESCRIPTION
This pull request bumps TypeScript to `5.8.0-beta` so we can try to implement the `erasableSyntaxOnly` option. 