### PR TITLE
Enable `erasableSyntaxOnly` flag

### DIFF
--- a/src/controller_property_definition.ts
+++ b/src/controller_property_definition.ts
@@ -10,28 +10,45 @@ import type { TSESTree } from "@typescript-eslint/typescript-estree"
 //
 // maybe the ControllerPropertyDefinition superclass should be Acorn.Node, but the subclasses themselves can narrow down the type
 type Node = Acorn.MethodDefinition | Acorn.PropertyDefinition | Acorn.ArrayExpression | Acorn.ObjectExpression
-type ElementNode = Acorn.Property | Acorn.PropertyDefinition | Acorn.ArrayExpression | Acorn.Literal | Acorn.Identifier | Acorn.MethodDefinition
+type ElementNode = Acorn.Property | Acorn.PropertyDefinition | Acorn.ArrayExpression | Acorn.Literal | Acorn.Identifier | Acorn.MethodDefinition
 
 export abstract class ControllerPropertyDefinition {
+  public readonly name: string
+  public readonly node: Node
+  public readonly elementNode: ElementNode
+  public readonly loc?: Acorn.SourceLocation | null
+  public readonly definitionType: "decorator" | "static" = "static"
+
   constructor(
-    public readonly name: string,
-    public readonly node: Node,
-    public readonly elementNode: ElementNode,
-    public readonly loc?: Acorn.SourceLocation | null,
-    public readonly definitionType: "decorator" | "static" = "static",
-  ) {}
+    name: string,
+    node: Node,
+    elementNode: ElementNode,
+    loc?: Acorn.SourceLocation | null,
+    definitionType: "decorator" | "static" = "static",
+  ) {
+    this.name = name
+    this.node = node
+    this.elementNode = elementNode
+    this.loc = loc
+    this.definitionType = definitionType
+  }
 }
 
 export class ValueDefinition extends ControllerPropertyDefinition {
+  public readonly definition: ValueDefinitionType
+  private propertyNode: Acorn.Property
+
   constructor(
     name: string,
-    public readonly definition: ValueDefinitionType,
+    definition: ValueDefinitionType,
     node: Node,
-    private propertyNode: Acorn.Property,
+    propertyNode: Acorn.Property,
     loc?: Acorn.SourceLocation | null,
     definitionType: "decorator" | "static" = "static",
   ) {
     super(name, node, propertyNode, loc, definitionType)
+    this.definition = definition
+    this.propertyNode = propertyNode
   }
 
   get type() {

--- a/src/parse_error.ts
+++ b/src/parse_error.ts
@@ -1,12 +1,22 @@
 import type { SourceLocation } from "acorn"
 
 export class ParseError {
+  public readonly severity: "LINT" | "FAIL";
+  public readonly message: string;
+  public readonly loc?: SourceLocation | null;
+  public readonly cause?: Error;
+
   constructor(
-    public readonly severity: "LINT" | "FAIL",
-    public readonly message: string,
-    public readonly loc?: SourceLocation | null,
-    public readonly cause?: Error,
-  ) {}
+    severity: "LINT" | "FAIL",
+    message: string,
+    loc?: SourceLocation | null,
+    cause?: Error,
+  ) {
+    this.severity = severity;
+    this.message = message;
+    this.loc = loc;
+    this.cause = cause;
+  }
 
   get inspect(): object {
     return {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,7 @@
     "declaration": true,
     "outDir": "dist",
     "rootDir": "src",
+    "erasableSyntaxOnly": true,
     "typeRoots": [
       "./types",
       "./node_modules/@types"


### PR DESCRIPTION
This pull request enables the `erasableSyntaxOnly` flag and includes the required changes to refactor away the "parameter properties in classes" shorthands.

https://devblogs.microsoft.com/typescript/announcing-typescript-5-8-beta/#the---erasablesyntaxonly-option