### PR TITLE
Fix registered controllers getting duplicated after project refresh

### DIFF
--- a/src/project.ts
+++ b/src/project.ts
@@ -246,6 +246,8 @@ export class Project {
       controllersFiles.push(this.applicationFile.sourceFile)
     }
 
+    this.controllersIndexFiles = []
+
     controllersFiles.forEach(controllersFile =>
       this.controllersIndexFiles.push(new ControllersIndexFile(this, controllersFile))
     )

--- a/test/project/lifecycle.test.ts
+++ b/test/project/lifecycle.test.ts
@@ -43,21 +43,26 @@ describe("Project", () => {
   test("doesn't re-add files when calling initialize() once and refresh() more than once", async () => {
     expect(project.projectFiles.length).toEqual(0)
     expect(project.controllerDefinitions.length).toEqual(0)
+    expect(project.registeredControllers).toHaveLength(0)
 
     await project.initialize()
     expect(project.projectFiles).toHaveLength(4)
     expect(project.controllerDefinitions).toHaveLength(2)
+    expect(project.registeredControllers).toHaveLength(2)
 
     await project.refresh()
     expect(project.projectFiles).toHaveLength(4)
     expect(project.controllerDefinitions).toHaveLength(2)
+    expect(project.registeredControllers).toHaveLength(2)
 
     await project.refresh()
     expect(project.projectFiles).toHaveLength(4)
     expect(project.controllerDefinitions).toHaveLength(2)
+    expect(project.registeredControllers).toHaveLength(2)
 
     await project.refresh()
     expect(project.projectFiles).toHaveLength(4)
     expect(project.controllerDefinitions).toHaveLength(2)
+    expect(project.registeredControllers).toHaveLength(2)
   })
 })


### PR DESCRIPTION
This fixes duplication of autocompleted controller names in Zed.

Fixes https://github.com/marcoroth/stimulus-parser/issues/402
