### PR TITLE
Remove npm security placeholder for the fs package

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,6 @@
     "@typescript-eslint/visitor-keys": "^8.46.2",
     "acorn-walk": "^8.3.4",
     "astring": "^1.9.0",
-    "fs": "^0.0.1-security",
     "glob": "^13.0.0"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -607,11 +607,6 @@ flatted@^3.3.3:
   resolved "https://registry.yarnpkg.com/flatted/-/flatted-3.4.2.tgz#f5c23c107f0f37de8dbdf24f13722b3b98d52726"
   integrity sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA==
 
-fs@^0.0.1-security:
-  version "0.0.1-security"
-  resolved "https://registry.yarnpkg.com/fs/-/fs-0.0.1-security.tgz#8a7bd37186b6dddf3813f23858b57ecaaf5e41d4"
-  integrity sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w==
-
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.3.tgz#cac6407785d03675a2a5e1a5305c697b347d90d6"


### PR DESCRIPTION
Our supply chain security tooling [blocked](https://socket.dev/npm/package/fs) this package install when I tried to work on Herb 😅 it can be removed since it's built-in.